### PR TITLE
[BUGFIX] Fixes errors that occur when the same form is used multiple times on the same page

### DIFF
--- a/Classes/ViewHelpers/Misc/PrefillFieldViewHelper.php
+++ b/Classes/ViewHelpers/Misc/PrefillFieldViewHelper.php
@@ -141,7 +141,7 @@ class PrefillFieldViewHelper extends AbstractViewHelper
      */
     protected function getFromMarker($value)
     {
-        if (empty($value) && isset($this->piVars['field'][$this->getMarker()])) {
+        if (empty($value) && isset($this->piVars['field'][$this->getMarker()]) && $this->isSameContentElement()) {
             $value = $this->piVars['field'][$this->getMarker()];
         }
         return $value;
@@ -155,7 +155,7 @@ class PrefillFieldViewHelper extends AbstractViewHelper
      */
     protected function getFromRawMarker($value)
     {
-        if (empty($value) && isset($this->piVars[$this->getMarker()])) {
+        if (empty($value) && isset($this->piVars[$this->getMarker()]) && $this->isSameContentElement()) {
             $value = $this->piVars[$this->getMarker()];
         }
         return $value;
@@ -364,5 +364,36 @@ class PrefillFieldViewHelper extends AbstractViewHelper
         $this->contentObject = ObjectUtility::getObjectManager()->get(ContentObjectRenderer::class);
         $configurationService = ObjectUtility::getObjectManager()->get(ConfigurationService::class);
         $this->configuration = $configurationService->getTypoScriptConfiguration();
+    }
+
+    /**
+     * Check whether GET / POST values may be used by this form,
+     * because they are from the same content element as the form was submitted
+     */
+    protected function isSameContentElement(): bool
+    {
+        $currentContentObjectData = $this->getCurrentContentObjectData();
+
+        if (isset($currentContentObjectData['uid']) && isset($this->piVars['field']['__ttcontentuid'])) {
+            return (int) $currentContentObjectData['uid'] === (int) $this->piVars['field']['__ttcontentuid'];
+        }
+
+        return true;
+    }
+
+    /**
+     * Retrieving data of content object that is currently being rendered
+     *
+     * @return array
+     */
+    protected function getCurrentContentObjectData(): array
+    {
+        $tsfe = ObjectUtility::getTyposcriptFrontendController();
+
+        if (isset($tsfe->applicationData['tx_powermail']['currentContentObjectData'])) {
+            return $tsfe->applicationData['tx_powermail']['currentContentObjectData'];
+        }
+
+        return [];
     }
 }

--- a/Classes/ViewHelpers/Misc/PrefillMultiFieldViewHelper.php
+++ b/Classes/ViewHelpers/Misc/PrefillMultiFieldViewHelper.php
@@ -184,7 +184,7 @@ class PrefillMultiFieldViewHelper extends AbstractViewHelper
     protected function getFromMarker()
     {
         $selected = false;
-        if (isset($this->variables['field'][$this->getMarker()])) {
+        if (isset($this->variables['field'][$this->getMarker()]) && $this->isSameContentElement()) {
             if (is_array($this->variables['field'][$this->getMarker()])) {
                 foreach (array_keys($this->variables['field'][$this->getMarker()]) as $key) {
                     if ($this->variables['field'][$this->getMarker()][$key] === $this->options[$this->index]['value'] ||
@@ -215,7 +215,7 @@ class PrefillMultiFieldViewHelper extends AbstractViewHelper
     protected function getFromRawMarker()
     {
         $selected = false;
-        if (isset($this->variables[$this->getMarker()])) {
+        if (isset($this->variables[$this->getMarker()]) && $this->isSameContentElement()) {
             if (is_array($this->variables[$this->getMarker()])) {
                 foreach (array_keys($this->variables[$this->getMarker()]) as $key) {
                     if ($this->variables[$this->getMarker()][$key] === $this->options[$this->index]['value'] ||
@@ -529,5 +529,36 @@ class PrefillMultiFieldViewHelper extends AbstractViewHelper
         $this->contentObjectRenderer = ObjectUtility::getObjectManager()->get(ContentObjectRenderer::class);
         $configurationService = ObjectUtility::getObjectManager()->get(ConfigurationService::class);
         $this->configuration = $configurationService->getTypoScriptConfiguration();
+    }
+
+    /**
+     * Check whether GET / POST values may be used by this form,
+     * because they are from the same content element as the form was submitted
+     */
+    protected function isSameContentElement(): bool
+    {
+        $currentContentObjectData = $this->getCurrentContentObjectData();
+
+        if (isset($currentContentObjectData['uid']) && isset($this->piVars['field']['__ttcontentuid'])) {
+            return (int) $currentContentObjectData['uid'] === (int) $this->piVars['field']['__ttcontentuid'];
+        }
+
+        return true;
+    }
+
+    /**
+     * Retrieving data of content object that is currently being rendered
+     *
+     * @return array
+     */
+    protected function getCurrentContentObjectData(): array
+    {
+        $tsfe = ObjectUtility::getTyposcriptFrontendController();
+
+        if (isset($tsfe->applicationData['tx_powermail']['currentContentObjectData'])) {
+            return $tsfe->applicationData['tx_powermail']['currentContentObjectData'];
+        }
+
+        return [];
     }
 }

--- a/Classes/ViewHelpers/Validation/EnableParsleyAndAjaxViewHelper.php
+++ b/Classes/ViewHelpers/Validation/EnableParsleyAndAjaxViewHelper.php
@@ -27,6 +27,7 @@ class EnableParsleyAndAjaxViewHelper extends AbstractValidationViewHelper
         parent::initializeArguments();
         $this->registerArgument('form', Form::class, 'Form', true);
         $this->registerArgument('additionalAttributes', 'array', 'additionalAttributes', false, []);
+        $this->registerArgument('ttContentData', 'array', 'ttContentData', false, []);
     }
 
     /**
@@ -50,6 +51,7 @@ class EnableParsleyAndAjaxViewHelper extends AbstractValidationViewHelper
         if ($this->settings['misc']['ajaxSubmit'] === '1') {
             $additionalAttributes['data-powermail-ajax'] = 'true';
             $additionalAttributes['data-powermail-form'] = $form->getUid();
+            $additionalAttributes['data-powermail-ttcontentuid'] = $this->arguments['ttContentData']['uid'];
 
             if ($this->addRedirectUri) {
                 /** @var RedirectUriService $redirectService */

--- a/Resources/Private/JavaScripts/Powermail/Form.js
+++ b/Resources/Private/JavaScripts/Powermail/Form.js
@@ -189,7 +189,7 @@ function PowermailForm($) {
 			if ($this.data('powermail-ajax-uri')) {
 				redirectUri = $this.data('powermail-ajax-uri');
 			}
-			var formUid = $this.data('powermail-form');
+			var ttContentUid = $this.data('powermail-ttcontentuid');
 
 			if (!regularSubmitOnAjax) {
 				$.ajax({
@@ -207,9 +207,9 @@ function PowermailForm($) {
  						fireAjaxCompleteEvent($txPowermail);
 					},
 					success: function(data) {
-						var html = $('*[data-powermail-form="' + formUid + '"]:first', data);
+						var html = $('*[data-powermail-ttcontentuid="' + ttContentUid + '"]:first', data);
 						if (html.length) {
-							$('*[data-powermail-form="' + formUid + '"]:first').closest('.tx-powermail').html(html);
+							$('*[data-powermail-ttcontentuid="' + ttContentUid + '"]:first').closest('.tx-powermail').html(html);
 							// fire tabs and parsley again
 							if ($.fn.powermailTabs) {
 								$('.powermail_morestep').powermailTabs();

--- a/Resources/Private/Templates/Form/Confirmation.html
+++ b/Resources/Private/Templates/Form/Confirmation.html
@@ -46,7 +46,7 @@ Show Confirmation Page
 					enctype="multipart/form-data"
 					class="visible-xs-inline-block visible-sm-inline-block visible-md-inline-block visible-lg-inline-block"
 					addQueryString="{settings.misc.addQueryString}"
-					additionalAttributes="{vh:Validation.EnableParsleyAndAjax(form: mail.form)}">
+					additionalAttributes="{vh:Validation.EnableParsleyAndAjax(form: mail.form, ttContentData: ttContentData)}">
 				<f:render section="HiddenFields" arguments="{_all}" />
 				<f:form.submit
 						value="{f:translate(key: 'confirmation_next')}"
@@ -73,5 +73,6 @@ Show Confirmation Page
 		</f:if>
 	</f:for>
 
+	<f:form.hidden name="field[__ttcontentuid]" value="{ttContentData.uid}" />
 	<f:form.hidden name="mail[form]" value="{mail.form.uid}" class="powermail_form_uid" />
 </f:section>

--- a/Resources/Private/Templates/Form/Create.html
+++ b/Resources/Private/Templates/Form/Create.html
@@ -19,7 +19,7 @@ NOTE: See example section after main section
 	</f:alias>
 
 
-	<div class="{settings.styles.framework.createClasses}" data-powermail-form="{mail.form.uid}">
+	<div class="{settings.styles.framework.createClasses}" data-powermail-form="{mail.form.uid}" data-powermail-ttcontentuid="{ttContentData.uid}">
 		<f:if condition="{optinActive}">
 			<f:else>
 				<vh:Misc.Variables mail="{mail}">

--- a/Resources/Private/Templates/Form/Form.html
+++ b/Resources/Private/Templates/Form/Form.html
@@ -20,7 +20,7 @@ Render Powermail Form
 						section="c{ttContentData.uid}"
 						name="field"
 						enctype="multipart/form-data"
-						additionalAttributes="{vh:Validation.EnableParsleyAndAjax(form:form)}"
+						additionalAttributes="{vh:Validation.EnableParsleyAndAjax(form:form,ttContentData:ttContentData)}"
 						addQueryString="{settings.misc.addQueryString}"
 						class="powermail_form powermail_form_{form.uid} {form.css} {settings.styles.framework.formClasses} {vh:Misc.MorestepClass(activate:settings.main.moresteps)}">
 
@@ -33,6 +33,7 @@ Render Powermail Form
 						<f:render partial="Form/Page" arguments="{_all}" />
 					</f:for>
 
+					<f:form.hidden name="field[__ttcontentuid]" value="{ttContentData.uid}" />
 					<f:form.hidden name="mail[form]" value="{form.uid}" class="powermail_form_uid" />
 					<f:render partial="Misc/HoneyPod" arguments="{form:form}" />
 				</f:form>


### PR DESCRIPTION
There are currently some issues when using the same form multiple times on the same page (tested with `TYPO3 v8.7.10` and `powermail v5.5.0`):

- On server side validation errors, all the forms with the same uid get filled in and validated
- When the form is successfully submitted, the success message always appears in the first form
- The emails are always sent to the recipients of the first form on the page

This pull request fixes the issues the following way:

- Adding an additional hidden field `__ttcontentuid` to the form containing the content element uid
- Checking the POST parameter `__ttcontentuid` in `FormController->forwardIfTtContentUidDoesNotMatch `  and forwarding to `formAction` if the uids do not match
- Checking for the correct content uid in the `PrefillViewHelpers` and only prefill from GET / POST variables if the content uids do match
- Inserting the Ajax response according to the attribute `data-powermail-ttcontentuid` instead of `data-powermail-form`

I am storing the data array of the current content object into `GLOBALS['TSFE']->applicationData` for two reasons (https://github.com/maechler/powermail/blob/develop/Classes/Controller/FormController.php#L478-L496):

1. The data array gets cleared when `errorAction` is called after the validation failed. The `errorAction` redirects to the referring action `formAction` and thus the data array is missing when `formAction` wants to render the template. That means that the hidden field `__ttcontentuid` can not be filled in correctly when there are server side validation errors.
2. We also need this information in the `PrefillViewHelpers`, like this it is easily accessible. Another way would be to pass the data down from `Form.html` to the field templates (e.g. `Input.html`), but that would have a bigger impact on existing code.

If you have any suggestions to improve the code I would be happy to update the pull request.