### PR TITLE
[BUGFIX] Empty subject deactivates mailing

### DIFF
--- a/Classes/Controller/FormController.php
+++ b/Classes/Controller/FormController.php
@@ -488,7 +488,7 @@ class FormController extends AbstractController
      */
     protected function isSenderMailEnabled(): bool
     {
-        return $this->settings['sender']['enable'] === '1';
+        return $this->settings['sender']['enable'] === '1' && $this->settings['sender']['subject'] !== '';
     }
 
     /**
@@ -496,7 +496,7 @@ class FormController extends AbstractController
      */
     protected function isReceiverMailEnabled(): bool
     {
-        return $this->settings['receiver']['enable'] === '1';
+        return $this->settings['receiver']['enable'] === '1' && $this->settings['receiver']['subject'] !== '';
     }
 
     /**


### PR DESCRIPTION
Like it is described in the flexform, an empty subject should deactivate the mailing. Currently the users gets an error, that the mail could not be send.