### PR TITLE
Added sorting to the array of path values due to override the templat…

### DIFF
--- a/Classes/Utility/TemplateUtility.php
+++ b/Classes/Utility/TemplateUtility.php
@@ -34,6 +34,7 @@ class TemplateUtility extends AbstractUtility
         );
         if (!empty($extbaseConfig['view'][$part . 'RootPaths'])) {
             $templatePaths = $extbaseConfig['view'][$part . 'RootPaths'];
+            ksort($templatePaths);
             $templatePaths = array_values($templatePaths);
         }
         if (empty($templatePaths)) {


### PR DESCRIPTION
Added sorting to the array of path values due to override the template for the optin mail. The value in $extbaseConfig['view'][$part . 'RootPaths'] unexpectetly looks like this:

/var/www/web/typo3conf/ext/powermail/Classes/Utility/TemplateUtility.php:37:
array (size=3)
  3 => string 'EXT:project/Resources/Private/Layouts/Extensions/Powermail/' (length=59)
  0 => string 'EXT:powermail/Resources/Private/Layouts/' (length=40)
  1 => string 'EXT:powermail/Resources/Private/Layouts/' (length=40)
  
With a sorting you can overwrite the template as expected