### PR TITLE
[FIX] Validate fe_user data before setting the data to the mail model

### DIFF
--- a/Classes/Domain/Factory/MailFactory.php
+++ b/Classes/Domain/Factory/MailFactory.php
@@ -70,7 +70,11 @@ class MailFactory
     {
         if (FrontendUtility::isLoggedInFrontendUser()) {
             $userRepository = ObjectUtility::getObjectManager()->get(UserRepository::class);
-            $mail->setFeuser($userRepository->findByUid(FrontendUtility::getPropertyFromLoggedInFrontendUser('uid')));
+            $feUserUid = FrontendUtility::getPropertyFromLoggedInFrontendUser('uid');
+            $user = $userRepository->findByUid($feUserUid);
+            if ($user instanceof User) {
+                $mail->setFeuser($user);
+            }
         }
     }
 

--- a/Classes/Domain/Factory/MailFactory.php
+++ b/Classes/Domain/Factory/MailFactory.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 namespace In2code\Powermail\Domain\Factory;
 
 use In2code\Powermail\Domain\Model\Mail;
+use In2code\Powermail\Domain\Model\User;
 use In2code\Powermail\Domain\Repository\MailRepository;
 use In2code\Powermail\Domain\Repository\UserRepository;
 use In2code\Powermail\Utility\ConfigurationUtility;


### PR DESCRIPTION
Check if the fetched user data has the correct type, before setting it to the mail object.
See Issue issues #549 