### PR TITLE
FEATURE: Add autocomplete attribute to form fields

### DIFF
--- a/Classes/Domain/Model/Field.php
+++ b/Classes/Domain/Model/Field.php
@@ -4,6 +4,7 @@ namespace In2code\Powermail\Domain\Model;
 
 use In2code\Powermail\Domain\Repository\FieldRepository;
 use In2code\Powermail\Exception\DeprecatedException;
+use In2code\Powermail\Enumeration\AutocompleteType;
 use In2code\Powermail\Utility\BackendUtility;
 use In2code\Powermail\Utility\FrontendUtility;
 use In2code\Powermail\Utility\ObjectUtility;
@@ -144,6 +145,24 @@ class Field extends AbstractEntity
      * @var \In2code\Powermail\Domain\Model\Page
      */
     protected $page = null;
+
+    /**
+     * autocomplete
+     *        Powermail field autocomplete types are:
+     *        "on", "off", "name", "honorific-prefix", "given-name", "additional-name", "family-name",
+     *        "honorific-suffix", "nickname", "username", "new-password", "current-password",
+     *        "organization-title", "organization", "street-address", "address-line1", "address-line2",
+     *        "address-line3", "address-level4", "address-level3", "address-level2",
+     *        "address-level1", "country", "country-name", "postal-code", "cc-name",
+     *        "cc-given-name", "cc-additional-name", "cc-family-name", "cc-number", "cc-exp",
+     *        "cc-exp-month", "cc-exp-year", "cc-csc", "cc-type", "transaction-currency",
+     *        "transaction-amount", "language", "bday", "bday-day", "bday-month", "bday-year",
+     *        "sex", "url", "photo", "tel", "tel-country-code", "tel-national", "tel-area-code",
+     *        "tel-local", "tel-local-prefix", "tel-local-suffix", "tel-extension", "email", "impp"
+     *
+     * @var string
+     */
+    protected $autocomplete = '';
 
     /**
      * @return string
@@ -822,5 +841,32 @@ class Field extends AbstractEntity
             }
         }
         return $types;
+    }
+
+    /**
+     * Returns the autocomplete. If the autocomplete value is invalid we return off state.
+     *
+     * @return string $autocomplete
+     */
+    public function getAutocomplete()
+    {
+        try {
+            $autocomplete = AutocompleteType::cast($this->autocomplete);
+        } catch (\TYPO3\CMS\Core\Type\Exception\InvalidEnumerationValueException $exception) {
+            $autocomplete = AutocompleteType::cast(AutocompleteType::OFF);
+        }
+
+        return $autocomplete;
+    }
+
+    /**
+     * Sets the autocomplete type
+     *
+     * @param string $autocomplete
+     * @return void
+     */
+    public function setAutocomplete($autocomplete)
+    {
+        $this->autocomplete = $autocomplete;
     }
 }

--- a/Classes/Enumeration/AutocompleteType.php
+++ b/Classes/Enumeration/AutocompleteType.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+namespace In2code\Powermail\Enumeration;
+
+/**
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Core\Type\Enumeration;
+
+class AutocompleteType extends Enumeration
+{
+
+    const ON = 'on';
+    const OFF = 'off';
+    const NAME = 'name';
+    const HONORIFIC_PREFIX = 'honorific-prefix';
+    const GIVEN_NAME = 'given-name';
+    const ADDITIONAL_NAME = 'additional-name';
+    const FAMILY_NAME = 'family-name';
+    const HONORIFIC_SUFFIX = 'honorific-suffix';
+    const NICKNAME = 'nickname';
+    const USERNAME = 'username';
+    const NEW_PASSWORD = 'new-password';
+    const CURRENT_PASSWORD = 'current-password';
+    const ORGANIZATION_TITLE = 'organization-title';
+    const ORGANIZATION = 'organization';
+    const STREET_ADDRESS = 'street-address';
+    const ADDRESS_LINE1 = 'address-line1';
+    const ADDRESS_LINE2 = 'address-line2';
+    const ADDRESS_LINE3 = 'address-line3';
+    const ADDRESS_LEVEL4 = 'address-level4';
+    const ADDRESS_LEVEL3 = 'address-level3';
+    const ADDRESS_LEVEL2 = 'address-level2';
+    const ADDRESS_LEVEL1 = 'address-level1';
+    const COUNTRY = 'country';
+    const COUNTRY_NAME = 'country-name';
+    const POSTAL_CODE = 'postal-code';
+    const CC_NAME = 'cc-name';
+    const CC_GIVEN_NAME = 'cc-given-name';
+    const CC_ADDITIONAL_NAME = 'cc-additional-name';
+    const CC_FAMILY_NAME = 'cc-family-name';
+    const CC_NUMBER = 'cc-number';
+    const CC_EXP = 'cc-exp';
+    const CC_EXP_MONTH = 'cc-exp-month';
+    const CC_EXP_YEAR = 'cc-exp-year';
+    const CC_CSC = 'cc-csc';
+    const CC_TYPE = 'cc-type';
+    const TRANSACTION_CURRENCY = 'transaction-currency';
+    const TRANSACTION_AMOUNT = 'transaction-amount';
+    const LANGUAGE = 'language';
+    const BDAY = 'bday';
+    const BDAY_DAY = 'bday-day';
+    const BDAY_MONTH = 'bday-month';
+    const BDAY_YEAR = 'bday-year';
+    const SEX = 'sex';
+    const URL = 'url';
+    const PHOTO = 'photo';
+    const TEL = 'tel';
+    const TEL_COUNTRY_CODE = 'tel-country-code';
+    const TEL_NATIONAL = 'tel-national';
+    const TEL_AREA_CODE = 'tel-area-code';
+    const TEL_LOCAL = 'tel-local';
+    const TEL_LOCAL_PREFIX = 'tel-local-prefix';
+    const TEL_LOCAL_SUFFIX = 'tel-local-suffix';
+    const TEL_EXTENSION = 'tel-extension';
+    const EMAIL = 'email';
+    const IMPP = 'impp';
+
+}

--- a/Configuration/TCA/tx_powermail_domain_model_field.php
+++ b/Configuration/TCA/tx_powermail_domain_model_field.php
@@ -14,6 +14,7 @@ $typeDefault = 'page, title, type, ' .
     '--div--;LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' . Field::TABLE_NAME . '.sheet1, ' .
     '--palette--;LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
         Field::TABLE_NAME . '.validation_title;2, ' .
+    '--palette--;Autocomplete;50, ' .
     '--palette--;LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
         Field::TABLE_NAME . '.prefill_title;32, ' .
     '--palette--;Layout;43, ' .
@@ -53,6 +54,7 @@ $typeSettingsMultiple = 'page, title, type, settings, ' .
     '--div--;LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' . Field::TABLE_NAME . '.sheet1, ' .
     '--palette--;LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
         Field::TABLE_NAME . '.validation_title;21, ' .
+    '--palette--;Autocomplete;50, ' .
     '--palette--;LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
         Field::TABLE_NAME . '.prefill_title;33, ' .
     '--palette--;Layout;41, ' .
@@ -98,6 +100,7 @@ $typeSmallPrefill = 'page, title, type, ' .
     '--div--;LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' . Field::TABLE_NAME . '.sheet1, ' .
     '--palette--;LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
         Field::TABLE_NAME . '.prefill_title;31, ' .
+    '--palette--;Autocomplete;50, ' .
     '--palette--;LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
         Field::TABLE_NAME . '.marker_title;5, ' .
     '--div--;LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:tabs.access, ' .
@@ -111,6 +114,7 @@ $typeSmallPrefillDescription = 'page, title, type, ' .
     '--div--;LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' . Field::TABLE_NAME . '.sheet1, ' .
     '--palette--;LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
         Field::TABLE_NAME . '.validation_title;21, ' .
+    '--palette--;Autocomplete;50, ' .
     '--palette--;LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
         Field::TABLE_NAME . '.prefill_title;31, ' .
     '--palette--;Layout;43, ' .
@@ -184,6 +188,7 @@ $typeDate = 'page, title, type, ' .
     '--div--;LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' . Field::TABLE_NAME . '.sheet1, ' .
     '--palette--;LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
         Field::TABLE_NAME . '.validation_title;21, ' .
+    '--palette--;Autocomplete;50, ' .
     '--palette--;Layout;42, ' .
     'description, ' .
     '--palette--;LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
@@ -273,6 +278,10 @@ $fieldsTca = [
         ],
         '5' => [
             'showitem' => 'auto_marker, marker, own_marker_select',
+            'canNotCollapse' => 1
+        ],
+        '50' => [
+            'showitem' => 'autocomplete',
             'canNotCollapse' => 1
         ],
         'canNotCollapse' => '1'
@@ -1037,6 +1046,327 @@ $fieldsTca = [
                 'foreign_table_where' => 'AND ' . Page::TABLE_NAME . '.pid=###CURRENT_PID### ' .
                     'AND ' . Page::TABLE_NAME . '.sys_language_uid IN (-1,###REC_FIELD_sys_language_uid###)',
                 'default' => 0
+            ],
+        ],
+        'autocomplete' => [
+            'l10n_mode' => 'exclude',
+            'exclude' => 0,
+            'label' =>
+                'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' . Field::TABLE_NAME . '.autocomplete',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.spacer1',
+                        '--div--'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.on',
+                        'on'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.off',
+                        'off'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.spacer2',
+                        '--div--'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.name',
+                        'name'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.honorific-prefix',
+                        'honorific-prefix'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.given-name',
+                        'given-name'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.additional-name',
+                        'additional-name'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.family-name',
+                        'family-name'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.honorific-suffix',
+                        'honorific-suffix'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.nickname',
+                        'nickname'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.spacer3',
+                        '--div--'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.tel',
+                        'tel'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.tel-country-code',
+                        'tel-country-code'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.tel-national',
+                        'tel-national'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.tel-area-code',
+                        'tel-area-code'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.tel-local',
+                        'tel-local'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.tel-local-prefix',
+                        'tel-local-prefix'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.tel-local-suffix',
+                        'tel-local-suffix'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.tel-extension',
+                        'tel-extension'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.username',
+                        'username'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.new-password',
+                        'new-password'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.current-password',
+                        'current-password'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.organization-title',
+                        'organization-title'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.organization',
+                        'organization'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.spacer4',
+                        '--div--'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.street-address',
+                        'street-address'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.address-line1',
+                        'address-line1'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.address-line2',
+                        'address-line2'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.address-line3',
+                        'address-line3'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.address-level4',
+                        'address-level4'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.address-level3',
+                        'address-level3'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.address-level2',
+                        'address-level3'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.address-level1',
+                        'address-level1'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.country',
+                        'country'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.country-name',
+                        'country-name'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.postal-code',
+                        'postal-code'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.spacer6',
+                        '--div--'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.cc-name',
+                        'cc-name'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.cc-given-name',
+                        'cc-given-name'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.cc-additional-name',
+                        'cc-additional-name'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.cc-family-name',
+                        'cc-family-name'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.cc-number',
+                        'cc-number'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.cc-exp',
+                        'input'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.cc-exp-month',
+                        'cc-exp-month'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.cc-exp-year',
+                        'cc-exp-year'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.cc-csc',
+                        'cc-csc'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.cc-type',
+                        'cc-type'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.spacer5',
+                        '--div--'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.transaction-currency',
+                        'transaction-currency'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.transaction-amount',
+                        'transaction-amount'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.language',
+                        'language'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.bday',
+                        'bday'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.bday-day',
+                        'bday-day'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.bday-month',
+                        'bday-month'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.bday-year',
+                        'bday-year'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.sex',
+                        'sex'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.url',
+                        'url'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.photo',
+                        'photo'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.email',
+                        'email'
+                    ],
+                    [
+                        'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' .
+                        Field::TABLE_NAME . '.autocomplete.impp',
+                        'impp'
+                    ],
+                ],
+                'default' => \In2code\Powermail\Enumeration\AutocompleteType::OFF,
+                'size' => 1,
+                'maxitems' => 1,
+                'eval' => 'required',
             ],
         ],
         'sorting' => [

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -900,6 +900,199 @@
 				<source>More ...</source>
 				<target state="translated">Mehr ...</target>
 			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete">
+				<source>Autocomplete</source>
+				<target state="translated">Autocomplete</target>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.spacer1">
+				<source>General</source>
+				<target state="translated">Allgemein</target>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.spacer2">
+				<source>Name</source>
+				<target state="translated">Name</target>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.spacer3">
+				<source>Telephone</source>
+				<target state="translated">Telefon</target>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.spacer4">
+				<source>Address</source>
+				<target state="translated">Adresse</target>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.spacer5">
+				<source>Misc</source>
+				<target state="translated">Sonstige</target>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.spacer6">
+				<source>Credit card</source>
+				<target state="translated">Kreditkarte</target>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.on">
+				<source>on</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.off">
+				<source>off</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.name">
+				<source>name</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.honorific-prefix">
+				<source>honorific prefix</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.given-name">
+				<source>given name</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.additional-name">
+				<source>additional name</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.family-name">
+				<source>family name</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.honorific-suffix">
+				<source>honorific suffix</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.nickname">
+				<source>nickname</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.username">
+				<source>username</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.new-password">
+				<source>new password</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.current-password">
+				<source>current password</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.organization-title">
+				<source>organization title</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.organization">
+				<source>organization</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.street-address">
+				<source>street address</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-line1">
+				<source>address line 1</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-line2">
+				<source>address line 2</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-line3">
+				<source>address line 3</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-level4">
+				<source>address level 4</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-level3">
+				<source>address level 3</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-level2">
+				<source>address level 2</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-level1">
+				<source>address level 1</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.country">
+				<source>country</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.country-name">
+				<source>country name</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.postal-code">
+				<source>postal code</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-name">
+				<source>name</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-given-name">
+				<source>given name</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-additional-name">
+				<source>additional name</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-family-name">
+				<source>family name</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-number">
+				<source>number</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-exp">
+				<source>expiration date</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-exp-month">
+				<source>expiration month</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-exp-year">
+				<source>expiration year</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-csc">
+				<source>security code </source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-type">
+				<source>type</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.transaction-currency">
+				<source>transaction currency</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.transaction-amount">
+				<source>transaction amount</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.language">
+				<source>language</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.bday">
+				<source>birthday</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.bday-day">
+				<source>birthday day</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.bday-month">
+				<source>birthday month</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.bday-year">
+				<source>birthday year</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.sex">
+				<source>sex</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.url">
+				<source>url</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.photo">
+				<source>photo</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel">
+				<source>telephone</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-country-code">
+				<source>telephone country code</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-national">
+				<source>telephone national</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-area-code">
+				<source>ttelephone area code</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-local">
+				<source>telephone local</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-local-prefix">
+				<source>telephone local prefix</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-local-suffix">
+				<source>telephone local suffix</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-extension">
+				<source>telephone extension</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.email">
+				<source>email</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.impp">
+				<source>instant messaging protocol</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -929,169 +929,224 @@
 				<target state="translated">Kreditkarte</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.on">
-				<source>on</source>
+				<source>On</source>
+				<target state="translated">An</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.off">
-				<source>off</source>
+				<source>Off</source>
+				<target state="translated">Aus</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.name">
-				<source>name</source>
+				<source>Name</source>
+				<target state="translated">Name</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.honorific-prefix">
-				<source>honorific prefix</source>
+				<source>Honorific prefix</source>
+				<target state="translated">Ehren-Präfix</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.given-name">
-				<source>given name</source>
+				<source>Given name</source>
+				<target state="translated">Vorname</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.additional-name">
-				<source>additional name</source>
+				<source>Additional name</source>
+				<target state="translated">Zusätzlicher Name</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.family-name">
-				<source>family name</source>
+				<source>Family name</source>
+				<target state="translated">Nachname</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.honorific-suffix">
-				<source>honorific suffix</source>
+				<source>Honorific suffix</source>
+				<target state="translated">Ehren-Suffix</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.nickname">
-				<source>nickname</source>
+				<source>Nickname</source>
+				<target state="translated">Spitzname</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.username">
-				<source>username</source>
+				<source>Username</source>
+				<target state="translated">Nutzername</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.new-password">
-				<source>new password</source>
+				<source>New password</source>
+				<target state="translated">Neues Passwort</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.current-password">
-				<source>current password</source>
+				<source>Current password</source>
+				<target state="translated">Aktuelles Passwort</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.organization-title">
-				<source>organization title</source>
+				<source>Organization title</source>
+				<target state="translated">Organisationstitel</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.organization">
-				<source>organization</source>
+				<source>Organization</source>
+				<target state="translated">Organisation</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.street-address">
-				<source>street address</source>
+				<source>Street address</source>
+				<target state="translated">Adresse</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-line1">
-				<source>address line 1</source>
+				<source>Address line 1</source>
+				<target state="translated">Adresszeile 1</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-line2">
-				<source>address line 2</source>
+				<source>Address line 2</source>
+				<target state="translated">Adresszeile 2</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-line3">
-				<source>address line 3</source>
+				<source>Address line 3</source>
+				<target state="translated">Adresszeile 3</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-level4">
-				<source>address level 4</source>
+				<source>Address level 4</source>
+				<target state="translated">Adressenebene 4</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-level3">
-				<source>address level 3</source>
+				<source>Address level 3</source>
+				<target state="translated">Adressenebene 3</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-level2">
-				<source>address level 2</source>
+				<source>Address level 2</source>
+				<target state="translated">Adressenebene 2</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-level1">
-				<source>address level 1</source>
+				<source>Address level 1</source>
+				<target state="translated">Adressenebene 1</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.country">
-				<source>country</source>
+				<source>Country</source>
+				<target state="translated">Land</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.country-name">
-				<source>country name</source>
+				<source>Country name</source>
+				<target state="translated">Ländername</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.postal-code">
-				<source>postal code</source>
+				<source>Postal code</source>
+				<target state="translated">Postleitzahl</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-name">
-				<source>name</source>
+				<source>Name</source>
+				<target state="translated">Name</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-given-name">
-				<source>given name</source>
+				<source>Given name</source>
+				<target state="translated">Vorname</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-additional-name">
-				<source>additional name</source>
+				<source>Additional name</source>
+				<target state="translated">Zusätzlicher Name</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-family-name">
-				<source>family name</source>
+				<source>Family name</source>
+				<target state="translated">Nachname</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-number">
-				<source>number</source>
+				<source>Number</source>
+				<target state="translated">Zahl</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-exp">
-				<source>expiration date</source>
+				<source>Expiration date</source>
+				<target state="translated">Ablaufsdatum</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-exp-month">
-				<source>expiration month</source>
+				<source>Expiration month</source>
+				<target state="translated">Ablaufsmonat</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-exp-year">
-				<source>expiration year</source>
+				<source>Expiration year</source>
+				<target state="translated">Ablaufsjahr</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-csc">
-				<source>security code </source>
+				<source>Security code </source>
+				<target state="translated">Sicherheitscode</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-type">
-				<source>type</source>
+				<source>Type</source>
+				<target state="translated">Art</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.transaction-currency">
-				<source>transaction currency</source>
+				<source>Transaction currency</source>
+				<target state="translated">Transaktionswährung</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.transaction-amount">
-				<source>transaction amount</source>
+				<source>Transaction amount</source>
+				<target state="translated">Transaktionswert</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.language">
-				<source>language</source>
+				<source>Language</source>
+				<target state="translated">Sprache</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.bday">
-				<source>birthday</source>
+				<source>Birthday</source>
+				<target state="translated">Geburtstag</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.bday-day">
-				<source>birthday day</source>
+				<source>Birthday day</source>
+				<target state="translated">Geburtstagstag</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.bday-month">
-				<source>birthday month</source>
+				<source>Birthday month</source>
+				<target state="translated">Geburtstagsmonat</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.bday-year">
-				<source>birthday year</source>
+				<source>Birthday year</source>
+				<target state="translated">Geburtstagsjahr</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.sex">
-				<source>sex</source>
+				<source>Sex</source>
+				<target state="translated">Geschlecht</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.url">
-				<source>url</source>
+				<source>Url</source>
+				<target state="translated">URL</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.photo">
-				<source>photo</source>
+				<source>Photo</source>
+				<target state="translated">Foto</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel">
-				<source>telephone</source>
+				<source>Telephone</source>
+				<target state="translated">Telefon</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-country-code">
-				<source>telephone country code</source>
+				<source>Telephone country code</source>
+				<target state="translated">Telefon Ländercode</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-national">
-				<source>telephone national</source>
+				<source>Telephone national</source>
+				<target state="translated">Telefon national</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-area-code">
-				<source>ttelephone area code</source>
+				<source>Telephone area code</source>
+				<target state="translated">Telefonvorwahl</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-local">
-				<source>telephone local</source>
+				<source>Telephone local</source>
+				<target state="translated">Telefon lokal</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-local-prefix">
-				<source>telephone local prefix</source>
+				<source>Telephone local prefix</source>
+				<target state="translated">Lokales Telefonpräfix</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-local-suffix">
-				<source>telephone local suffix</source>
+				<source>Telephone local suffix</source>
+				<target state="translated">Lokales Telefonsuffix</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-extension">
-				<source>telephone extension</source>
+				<source>Telephone extension</source>
+				<target state="translated">Telefondurchwahl</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.email">
-				<source>email</source>
+				<source>Email</source>
+				<target state="translated">E-Mail</target>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.impp">
-				<source>instant messaging protocol</source>
+				<source>Instant messaging protocol</source>
+				<target state="translated">Instant Messaging-Protokoll</target>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -648,6 +648,192 @@
 			<trans-unit id="pluginInfo.more" resname="pluginInfo.more">
 				<source>More ...</source>
 			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete">
+				<source>Autocomplete</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.spacer1">
+				<source>General</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.spacer2">
+				<source>Name</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.spacer3">
+				<source>Telephone</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.spacer4">
+				<source>Address</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.spacer5">
+				<source>Misc</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.spacer6">
+				<source>Credit card</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.on">
+				<source>on</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.off">
+				<source>off</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.name">
+				<source>name</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.honorific-prefix">
+				<source>honorific prefix</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.given-name">
+				<source>given name</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.additional-name">
+				<source>additional name</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.family-name">
+				<source>family name</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.honorific-suffix">
+				<source>honorific suffix</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.nickname">
+				<source>nickname</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.username">
+				<source>username</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.new-password">
+				<source>new password</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.current-password">
+				<source>current password</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.organization-title">
+				<source>organization title</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.organization">
+				<source>organization</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.street-address">
+				<source>street address</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-line1">
+				<source>address line 1</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-line2">
+				<source>address line 2</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-line3">
+				<source>address line 3</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-level4">
+				<source>address level 4</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-level3">
+				<source>address level 3</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-level2">
+				<source>address level 2</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-level1">
+				<source>address level 1</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.country">
+				<source>country</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.country-name">
+				<source>country name</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.postal-code">
+				<source>postal code</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-name">
+				<source>name</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-given-name">
+				<source>given name</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-additional-name">
+				<source>additional name</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-family-name">
+				<source>family name</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-number">
+				<source>number</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-exp">
+				<source>expiration date</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-exp-month">
+				<source>expiration month</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-exp-year">
+				<source>expiration year</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-csc">
+				<source>security code </source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-type">
+				<source>type</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.transaction-currency">
+				<source>transaction currency</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.transaction-amount">
+				<source>transaction amount</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.language">
+				<source>language</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.bday">
+				<source>birthday</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.bday-day">
+				<source>birthday day</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.bday-month">
+				<source>birthday month</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.bday-year">
+				<source>birthday year</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.sex">
+				<source>sex</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.url">
+				<source>url</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.photo">
+				<source>photo</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel">
+				<source>telephone</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-country-code">
+				<source>telephone country code</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-national">
+				<source>telephone national</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-area-code">
+				<source>ttelephone area code</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-local">
+				<source>telephone local</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-local-prefix">
+				<source>telephone local prefix</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-local-suffix">
+				<source>telephone local suffix</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-extension">
+				<source>telephone extension</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.email">
+				<source>email</source>
+			</trans-unit>
+			<trans-unit id="tx_powermail_domain_model_field.autocomplete.impp">
+				<source>instant messaging protocol</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -670,169 +670,169 @@
 				<source>Credit card</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.on">
-				<source>on</source>
+				<source>On</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.off">
-				<source>off</source>
+				<source>Off</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.name">
-				<source>name</source>
+				<source>Name</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.honorific-prefix">
-				<source>honorific prefix</source>
+				<source>Honorific prefix</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.given-name">
-				<source>given name</source>
+				<source>Given name</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.additional-name">
-				<source>additional name</source>
+				<source>Additional name</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.family-name">
-				<source>family name</source>
+				<source>Family name</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.honorific-suffix">
-				<source>honorific suffix</source>
+				<source>Honorific suffix</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.nickname">
-				<source>nickname</source>
+				<source>Nickname</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.username">
-				<source>username</source>
+				<source>Username</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.new-password">
-				<source>new password</source>
+				<source>New password</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.current-password">
-				<source>current password</source>
+				<source>Current password</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.organization-title">
-				<source>organization title</source>
+				<source>Organization title</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.organization">
-				<source>organization</source>
+				<source>Organization</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.street-address">
-				<source>street address</source>
+				<source>Street address</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-line1">
-				<source>address line 1</source>
+				<source>Address line 1</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-line2">
-				<source>address line 2</source>
+				<source>Address line 2</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-line3">
-				<source>address line 3</source>
+				<source>Address line 3</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-level4">
-				<source>address level 4</source>
+				<source>Address level 4</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-level3">
-				<source>address level 3</source>
+				<source>Address level 3</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-level2">
-				<source>address level 2</source>
+				<source>Address level 2</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.address-level1">
-				<source>address level 1</source>
+				<source>Address level 1</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.country">
-				<source>country</source>
+				<source>Country</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.country-name">
-				<source>country name</source>
+				<source>Country name</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.postal-code">
-				<source>postal code</source>
+				<source>Postal code</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-name">
-				<source>name</source>
+				<source>Name</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-given-name">
-				<source>given name</source>
+				<source>Given name</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-additional-name">
-				<source>additional name</source>
+				<source>Additional name</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-family-name">
-				<source>family name</source>
+				<source>Family name</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-number">
-				<source>number</source>
+				<source>Number</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-exp">
-				<source>expiration date</source>
+				<source>Expiration date</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-exp-month">
-				<source>expiration month</source>
+				<source>Expiration month</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-exp-year">
-				<source>expiration year</source>
+				<source>Expiration year</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-csc">
-				<source>security code </source>
+				<source>Security code </source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.cc-type">
-				<source>type</source>
+				<source>Type</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.transaction-currency">
-				<source>transaction currency</source>
+				<source>Transaction currency</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.transaction-amount">
-				<source>transaction amount</source>
+				<source>Transaction amount</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.language">
-				<source>language</source>
+				<source>Language</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.bday">
-				<source>birthday</source>
+				<source>Birthday</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.bday-day">
-				<source>birthday day</source>
+				<source>Birthday day</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.bday-month">
-				<source>birthday month</source>
+				<source>Birthday month</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.bday-year">
-				<source>birthday year</source>
+				<source>Birthday year</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.sex">
-				<source>sex</source>
+				<source>Sex</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.url">
-				<source>url</source>
+				<source>Url</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.photo">
-				<source>photo</source>
+				<source>Photo</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel">
-				<source>telephone</source>
+				<source>Telephone</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-country-code">
-				<source>telephone country code</source>
+				<source>Telephone country code</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-national">
-				<source>telephone national</source>
+				<source>Telephone national</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-area-code">
-				<source>ttelephone area code</source>
+				<source>Telephone area code</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-local">
-				<source>telephone local</source>
+				<source>Telephone local</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-local-prefix">
-				<source>telephone local prefix</source>
+				<source>Telephone local prefix</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-local-suffix">
-				<source>telephone local suffix</source>
+				<source>Telephone local suffix</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.tel-extension">
-				<source>telephone extension</source>
+				<source>Telephone extension</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.email">
-				<source>email</source>
+				<source>Email</source>
 			</trans-unit>
 			<trans-unit id="tx_powermail_domain_model_field.autocomplete.impp">
-				<source>instant messaging protocol</source>
+				<source>Instant messaging protocol</source>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Partials/Form/Field/Check.html
+++ b/Resources/Private/Partials/Form/Field/Check.html
@@ -12,7 +12,7 @@
 							value="{setting.value}"
 							checked="{vh:misc.prefillMultiField(field:field, mail:mail, cycle:index.cycle)}"
 							id="powermail_field_{field.marker}_{index.cycle}"
-							additionalAttributes="{vh:validation.validationDataAttribute(field:field, iteration:index)}"
+							additionalAttributes="{vh:validation.validationDataAttribute(field:field, iteration:index, additionalAttributes:'{autocomplete: field.autocomplete}')}"
 							class="powermail_checkbox powermail_checkbox_{field.uid}" />
 					<vh:string.escapeLabels>{setting.label}</vh:string.escapeLabels>
 				</label>

--- a/Resources/Private/Partials/Form/Field/Country.html
+++ b/Resources/Private/Partials/Form/Field/Country.html
@@ -16,7 +16,7 @@
 				prependOptionLabel="{f:translate(key:'pleaseChoose')}"
 				class="powermail_country {settings.styles.framework.fieldClasses} {vh:validation.errorClass(field:field, class:'powermail_field_error')}"
 				value="{vh:misc.prefillField(field:field, mail:mail)}"
-				additionalAttributes="{vh:validation.validationDataAttribute(field:field)}"
+				additionalAttributes="{vh:validation.validationDataAttribute(field:field, additionalAttributes:'{autocomplete: field.autocomplete}')}"
 				id="powermail_field_{field.marker}" />
 	</div>
 </div>

--- a/Resources/Private/Partials/Form/Field/Date.html
+++ b/Resources/Private/Partials/Form/Field/Date.html
@@ -9,7 +9,7 @@
 				id="powermail_field_{field.marker}"
 				property="{field.marker}"
 				value="{vh:misc.prefillField(field:field, mail:mail)}"
-				additionalAttributes="{vh:validation.datepickerDataAttribute(field:field, value:'{vh:misc.prefillField(field:field)}')}"
+				additionalAttributes="{vh:validation.datepickerDataAttribute(field:field, additionalAttributes:'{autocomplete: field.autocomplete}', value:'{vh:misc.prefillField(field:field)}')}"
 				class="powermail_date {settings.styles.framework.fieldClasses} {vh:validation.errorClass(field:field, class:'powermail_field_error')}" />
 	</div>
 </div>

--- a/Resources/Private/Partials/Form/Field/Hidden.html
+++ b/Resources/Private/Partials/Form/Field/Hidden.html
@@ -3,4 +3,5 @@
 		id="powermail_field_{field.marker}"
 		property="{field.marker}"
 		value="{vh:misc.prefillField(field:field, mail:mail)}"
+		additionalAttributes="{autocomplete: field.autocomplete}"
 		class="powermail_hidden {field.css} powermail_{field.marker}" />

--- a/Resources/Private/Partials/Form/Field/Input.html
+++ b/Resources/Private/Partials/Form/Field/Input.html
@@ -10,7 +10,7 @@
 				placeholder="{field.placeholder}"
 				value="{vh:misc.prefillField(field:field, mail:mail)}"
 				class="powermail_input {settings.styles.framework.fieldClasses} {vh:validation.errorClass(field:field, class:'powermail_field_error')}"
-				additionalAttributes="{vh:validation.validationDataAttribute(field:field)}"
+				additionalAttributes="{vh:validation.validationDataAttribute(field:field, additionalAttributes:'{autocomplete: field.autocomplete}')}"
 				id="powermail_field_{field.marker}" />
 	</div>
 </div>

--- a/Resources/Private/Partials/Form/Field/Location.html
+++ b/Resources/Private/Partials/Form/Field/Location.html
@@ -8,7 +8,7 @@
 				id="powermail_field_{field.marker}"
 				property="{field.marker}"
 				value="{vh:misc.prefillField(field:field, mail:mail)}"
-				additionalAttributes="{data-powermail-location:'prefill'}"
+				additionalAttributes="{data-powermail-location:'prefill', autocomplete: field.autocomplete}"
 				class="powermail_location {settings.styles.framework.fieldClasses} {vh:validation.errorClass(field:field, class:'powermail_field_error')}" />
 	</div>
 </div>

--- a/Resources/Private/Partials/Form/Field/Select.html
+++ b/Resources/Private/Partials/Form/Field/Select.html
@@ -9,7 +9,7 @@
 				property="{field.marker}"
 				class="powermail_select {settings.styles.framework.fieldClasses} {vh:validation.errorClass(field:field, class:'powermail_field_error')}"
 				id="powermail_field_{field.marker}"
-				additionalAttributes="{vh:validation.validationDataAttribute(field:field)}"
+				additionalAttributes="{vh:validation.validationDataAttribute(field:field, additionalAttributes:'{autocomplete: field.autocomplete}')}"
 				multiple="{field.multiselectForField}"
 				value="{vh:misc.prefillField(field:field, mail:mail)}" />
 

--- a/Resources/Private/Partials/Form/Field/Textarea.html
+++ b/Resources/Private/Partials/Form/Field/Textarea.html
@@ -11,7 +11,7 @@
 				property="{field.marker}"
 				placeholder="{field.placeholder}"
 				value="{vh:misc.prefillField(field:field, mail:mail)}"
-				additionalAttributes="{vh:validation.validationDataAttribute(field:field)}"
+				additionalAttributes="{vh:validation.validationDataAttribute(field:field, additionalAttributes:'{autocomplete: field.autocomplete}')}"
 				class="powermail_textarea {settings.styles.framework.fieldClasses} {vh:validation.errorClass(field:field, class:'powermail_field_error')}" />
 		</div>
 </div>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -116,6 +116,7 @@ CREATE TABLE tx_powermail_domain_model_field (
 	mandatory tinyint(4) unsigned DEFAULT '0' NOT NULL,
 	own_marker_select tinyint(4) unsigned DEFAULT '0' NOT NULL,
 	marker varchar(255) DEFAULT '' NOT NULL,
+	autocomplete varchar(255) DEFAULT '' NOT NULL,
 
 	# Dummy Fields
 	auto_marker tinyint(2) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
For accessibility reasons form elements should have autocomplete fields.
To have just autocomplete with value on or off does not bring much value for the user.

So form editors should be able to define the field content type so that the auto complete knows which data could be used.

![Screenshot 2020-10-27 at 15 22 12](https://user-images.githubusercontent.com/1014126/97314864-6976f080-1868-11eb-9099-a5010d041244.png)

![Screenshot 2020-10-27 at 15 24 12](https://user-images.githubusercontent.com/1014126/97314958-814e7480-1868-11eb-9bcb-462f5298e19c.png)
