### PR TITLE
[BUGFIX] empty replyToEmail error for optin mails if settings.flexfor…

### DIFF
--- a/Classes/Domain/Service/Mail/SendOptinConfirmationMailPreflight.php
+++ b/Classes/Domain/Service/Mail/SendOptinConfirmationMailPreflight.php
@@ -65,6 +65,8 @@ class SendOptinConfirmationMailPreflight
      */
     public function sendOptinConfirmationMail(Mail $mail): void
     {
+        $senderService = ObjectUtility::getObjectManager()->get(SenderMailPropertiesService::class, $this->settings);
+
         $email = [
             'template' => 'Mail/OptinMail',
             'receiverEmail' => $this->mailRepository->getSenderMailFromArguments($mail),
@@ -72,10 +74,10 @@ class SendOptinConfirmationMailPreflight
                 $mail,
                 [$this->conf['sender.']['default.'], 'senderName']
             ),
-            'senderEmail' => $this->settings['sender']['email'],
-            'senderName' => $this->settings['sender']['name'],
-            'replyToEmail' => $this->settings['sender']['email'],
-            'replyToName' => $this->settings['sender']['name'],
+            'senderEmail' => $senderService->getSenderEmail(),
+            'senderName' => $senderService->getSenderName(),
+            'replyToEmail' => $senderService->getSenderEmail(),
+            'replyToName' => $senderService->getSenderName(),
             'subject' => ObjectUtility::getContentObject()->cObjGetSingle(
                 $this->conf['optin.']['subject'],
                 $this->conf['optin.']['subject.']


### PR DESCRIPTION
Fixes empty replyToEmail error for optin emails if settings.flexform.sender.email is not set. Allowes to use the default senderEmail defined in TypoScript