### PR TITLE
Bugfix: Skip boolean values in blacklist string check

### DIFF
--- a/Classes/Domain/Validator/SpamShield/ValueBlacklistMethod.php
+++ b/Classes/Domain/Validator/SpamShield/ValueBlacklistMethod.php
@@ -30,7 +30,10 @@ class ValueBlacklistMethod extends AbstractMethod
                 continue;
             }
             foreach ($this->getValues() as $blackword) {
-                if ($this->isStringInString($answer->getValue(), $blackword)) {
+                if (is_bool($answer->getValue()) {
+                    continue;   
+                }
+                if ($this->isStringInString((string)$answer->getValue(), $blackword)) {
                     return true;
                 }
             }

--- a/Classes/Domain/Validator/SpamShield/ValueBlacklistMethod.php
+++ b/Classes/Domain/Validator/SpamShield/ValueBlacklistMethod.php
@@ -30,7 +30,7 @@ class ValueBlacklistMethod extends AbstractMethod
                 continue;
             }
             foreach ($this->getValues() as $blackword) {
-                if (is_bool($answer->getValue()) {
+                if (is_bool($answer->getValue())) {
                     continue;   
                 }
                 if ($this->isStringInString((string)$answer->getValue(), $blackword)) {


### PR DESCRIPTION
This fixes the Exception

Argument 1 passed to In2code\Powermail\Domain\Validator\SpamShield\ValueBlacklistMethod::isStringInString() must be of the type string, bool given