### PR TITLE
[FEATURE] Add button to delete all mails and answers

### DIFF
--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -8,6 +8,8 @@ use In2code\Powermail\Domain\Repository\PageRepository;
 use In2code\Powermail\Utility\BackendUtility;
 use In2code\Powermail\Utility\BasicFileUtility;
 use In2code\Powermail\Utility\ConfigurationUtility;
+use In2code\Powermail\Utility\DatabaseUtility;
+use In2code\Powermail\Utility\LocalizationUtility;
 use In2code\Powermail\Utility\MailUtility;
 use In2code\Powermail\Utility\ReportingUtility;
 use In2code\Powermail\Utility\StringUtility;
@@ -59,6 +61,47 @@ class ModuleController extends AbstractController
                 'writeAccess' => $beUser->check('tables_modify', Answer::TABLE_NAME)
                     && $beUser->check('tables_modify', Mail::TABLE_NAME),
             ]
+        );
+    }
+
+    /**
+     * Delete all mails and answers if the confirmation checkbox has been checked
+     *
+     * @return void
+     */
+    public function deleteAllMailsBeAction(): void
+    {
+        $args = $this->request->getArguments();
+        if ($args['reallyDelete'] === '1' && $this->id > 0) {
+            $this->deleteAllMails();
+        }
+        $this->forward('list');
+    }
+
+    /**
+     * Delete all mails and answers on the current page
+     *
+     * @return void
+     */
+    protected function deleteAllMails(): void
+    {
+        $queryBuilder = DatabaseUtility::getQueryBuilderForTable(Answer::TABLE_NAME);
+        $queryBuilder->delete(Answer::TABLE_NAME)
+            ->where(
+                $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($this->id))
+            )
+            ->execute();
+
+        $queryBuilder = DatabaseUtility::getQueryBuilderForTable(Answer::TABLE_NAME);
+        $queryBuilder->delete(Mail::TABLE_NAME)
+            ->where(
+                $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($this->id))
+            )
+            ->execute();
+
+        $this->addFlashMessage(
+            LocalizationUtility::translate('BackendDeleteAllMailsFinished'),
+            ''
         );
     }
 

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -747,6 +747,26 @@
 				<source>This TYPO3 instance is running in development context. You can use %s in the AdditionalConfiguration.php to enforce powermail to send testmails to this email-address only.</source>
 				<target state="translated">Diese TYPO3-Instanz läuft aktuell im Development Context. Mit %s in der AdditionalConfiguration.php kann man powermail anweisen, nur noch an diese Formulare zu senden.</target>
 			</trans-unit>
+			<trans-unit id="BackendDeleteAllMailsButton">
+				<source>Cleanup</source>
+				<target state="translated">Aufräumen</target>
+			</trans-unit>
+			<trans-unit id="BackendDeleteAllMailsTitle">
+				<source>Delete all mails</source>
+				<target state="translated">Alle Mails löschen</target>
+			</trans-unit>
+			<trans-unit id="BackendDeleteAllMailsFinished">
+				<source>All mails and answers on this page have been deleted</source>
+				<target state="translated">Alle Mails und Antworten auf dieser Seite wurden gelöscht.</target>
+			</trans-unit>
+			<trans-unit id="BackendDeleteAllMailsReally">
+				<source>Yes, delete all mails and answers on this page</source>
+				<target state="translated">Ja, alle Mails und Antworten auf dieser Seite löschen</target>
+			</trans-unit>
+			<trans-unit id="BackendDeleteAllMailSubmit">
+				<source>Delete all</source>
+				<target state="translated">Alle löschen</target>
+			</trans-unit>
 			<trans-unit id="BackendOverviewTitle">
 				<source>Form Overview</source>
 				<target state="translated">Formular Übersicht</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -559,6 +559,21 @@
 			<trans-unit id="BackendCheckDevelopmentContextAvailable" resname="BackendCheckDevelopmentContextAvailable">
 				<source>This TYPO3 instance is running in development context. You can use %s in the AdditionalConfiguration.php to enforce powermail to send testmails to this email-address only.</source>
 			</trans-unit>
+			<trans-unit id="BackendDeleteAllMailsButton">
+				<source>Cleanup</source>
+			</trans-unit>
+			<trans-unit id="BackendDeleteAllMailsTitle">
+				<source>Delete all mails</source>
+			</trans-unit>
+			<trans-unit id="BackendDeleteAllMailsFinished">
+				<source>All mails and answers on this page have been deleted</source>
+			</trans-unit>
+			<trans-unit id="BackendDeleteAllMailsReally">
+				<source>Yes, delete all mails and answers on this page</source>
+			</trans-unit>
+			<trans-unit id="BackendDeleteAllMailSubmit">
+				<source>Delete all</source>
+			</trans-unit>
 			<trans-unit id="BackendOverviewTitle" resname="BackendOverviewTitle">
 				<source>Form Overview</source>
 			</trans-unit>

--- a/Resources/Private/Partials/Module/DeleteAllMails.html
+++ b/Resources/Private/Partials/Module/DeleteAllMails.html
@@ -1,0 +1,41 @@
+<div class="clearfix">
+	<div class="pull-right">
+		<f:form.button
+				class="btn btn-default"
+				type="button"
+				additionalAttributes="{data-toggle:'collapse',data-target:'#deleteAllMails',aria-expanded:'false',aria-controls:'collapseExample'}">
+			<f:translate key="BackendDeleteAllMailsButton">Cleanup</f:translate>
+		</f:form.button>
+	</div>
+</div>
+
+<div class="collapse" id="deleteAllMails">
+	<h2 class="powermail-padding-top" id="deleteAllMails">
+		<f:translate key="BackendDeleteAllMailsTitle">Delete all mails</f:translate>
+	</h2>
+
+	<div class="message-body powermail-padding-bottom powermail_email">
+	    <f:form
+				class="form-horizontal"
+				action="deleteAllMailsBe">
+			<f:form.hidden name="mode" value="deleteAllMails"/>
+			<div class="form-group">
+				<div class="col-sm-6 checkbox">
+					<label>
+						<f:form.checkbox
+								name="reallyDelete"
+								value="1"
+								additionalAttributes="{required:''}"
+								/>
+						<f:translate key="BackendDeleteAllMailsReally" />
+					</label>
+				</div>
+				<div class="col-sm-6">
+					<f:form.button type="submit" class="btn btn-primary">
+						<f:translate key="BackendDeleteAllMailSubmit"/>
+					</f:form.button>
+				</div>
+			</div>
+		</f:form>
+	</div>
+</div>

--- a/Resources/Private/Templates/Module/List.html
+++ b/Resources/Private/Templates/Module/List.html
@@ -39,4 +39,8 @@
 		</f:if>
 	</div>
 
+	<f:if condition="{writeAccess}">
+		<f:render partial="Module/DeleteAllMails" arguments="{_all}" />
+	</f:if>
+
 </f:section>

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -21,6 +21,7 @@ call_user_func(
                 [
                     \In2code\Powermail\Controller\ModuleController::class =>
                         'dispatch, list, exportXls, exportCsv, reportingBe, toolsBe, overviewBe, ' .
+                        'deleteAllMailsBe, ' .
                         'checkBe, converterBe, converterUpdateBe, reportingFormBe, reportingMarketingBe, ' .
                         'fixUploadFolder, fixWrongLocalizedForms, fixFilledMarkersInLocalizedFields, ' .
                         'fixWrongLocalizedPages, fixFilledMarkersInLocalizedPages'


### PR DESCRIPTION
The "Mail list" page has a "cleanup" button that opens a small form
which allows one to delete all mails and answers on the current page.

Port of the old patch from 2018
 https://github.com/einpraegsam/powermail/pull/304