### PR TITLE
[FEATURE] Unique field ids

### DIFF
--- a/Classes/ViewHelpers/Validation/PasswordValidationDataAttributeViewHelper.php
+++ b/Classes/ViewHelpers/Validation/PasswordValidationDataAttributeViewHelper.php
@@ -13,6 +13,15 @@ class PasswordValidationDataAttributeViewHelper extends ValidationDataAttributeV
 {
 
     /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('ttContentUid', 'int', 'UID of content element', false);
+    }
+
+    /**
      * Returns Data Attribute Array for JS validation with parsley.js
      *
      * @return array for data attributes
@@ -25,7 +34,11 @@ class PasswordValidationDataAttributeViewHelper extends ValidationDataAttributeV
         if ($this->isClientValidationEnabled()) {
             /** @var Field $field */
             $field = $this->arguments['field'];
+            $ttContentUid = $this->arguments['ttContentUid'];
             $additionalAttributes['data-parsley-equalto'] = '#powermail_field_' . $field->getMarker();
+            if ($ttContentUid) {
+                $additionalAttributes['data-parsley-equalto'] = $additionalAttributes['data-parsley-equalto'] . '_' . $ttContentUid;
+            }
             $additionalAttributes['data-parsley-equalto-message'] =
                 LocalizationUtility::translate('validationerror_password');
         }

--- a/Resources/Private/Partials/Form/Field/Captcha.html
+++ b/Resources/Private/Partials/Form/Field/Captcha.html
@@ -5,7 +5,7 @@
 
 	<div class="{settings.styles.framework.fieldWrappingClasses} {vh:validation.errorClass(field:field, class: 'powermail_field_error')}">
 		<f:form.textfield
-				id="powermail_field_{field.marker}"
+				id="powermail_field_{field.marker}_{ttContentUid}"
 				property="{field.marker}"
 				value=""
 				class="powermail_captcha {settings.styles.framework.fieldClasses} {vh:validation.errorClass(field:field, class:'powermail_field_error')}"

--- a/Resources/Private/Partials/Form/Field/Check.html
+++ b/Resources/Private/Partials/Form/Field/Check.html
@@ -11,7 +11,7 @@
 							property="{field.marker}."
 							value="{setting.value}"
 							checked="{vh:misc.prefillMultiField(field:field, mail:mail, cycle:index.cycle)}"
-							id="powermail_field_{field.marker}_{index.cycle}"
+							id="powermail_field_{field.marker}_{ttContentUid}_{index.cycle}"
 							additionalAttributes="{vh:validation.validationDataAttribute(field:field, iteration:index)}"
 							class="powermail_checkbox powermail_checkbox_{field.uid}" />
 					<vh:string.escapeLabels>{setting.label}</vh:string.escapeLabels>

--- a/Resources/Private/Partials/Form/Field/Country.html
+++ b/Resources/Private/Partials/Form/Field/Country.html
@@ -17,6 +17,6 @@
 				class="powermail_country {settings.styles.framework.fieldClasses} {vh:validation.errorClass(field:field, class:'powermail_field_error')}"
 				value="{vh:misc.prefillField(field:field, mail:mail)}"
 				additionalAttributes="{vh:validation.validationDataAttribute(field:field)}"
-				id="powermail_field_{field.marker}" />
+				id="powermail_field_{field.marker}_{ttContentUid}" />
 	</div>
 </div>

--- a/Resources/Private/Partials/Form/Field/Date.html
+++ b/Resources/Private/Partials/Form/Field/Date.html
@@ -6,7 +6,7 @@
 	<div class="{settings.styles.framework.fieldWrappingClasses}">
 		<f:form.textfield
 				type="{field.datepickerSettingsOptimized}"
-				id="powermail_field_{field.marker}"
+				id="powermail_field_{field.marker}_{ttContentUid}"
 				property="{field.marker}"
 				value="{vh:misc.prefillField(field:field, mail:mail)}"
 				additionalAttributes="{vh:validation.datepickerDataAttribute(field:field, value:'{vh:misc.prefillField(field:field)}')}"

--- a/Resources/Private/Partials/Form/Field/File.html
+++ b/Resources/Private/Partials/Form/Field/File.html
@@ -5,7 +5,7 @@
 
 	<div class="{settings.styles.framework.fieldWrappingClasses}">
 		<vh:form.multiUpload
-				id="powermail_field_{field.marker}"
+				id="powermail_field_{field.marker}_{ttContentUid}"
 				property="{field.marker}"
 				additionalAttributes="{vh:validation.uploadAttributes(field:field)}"
 				class="powermail_file {settings.styles.framework.fieldClasses} {vh:validation.errorClass(field:field, class: 'powermail_field_error')}" />

--- a/Resources/Private/Partials/Form/Field/Hidden.html
+++ b/Resources/Private/Partials/Form/Field/Hidden.html
@@ -1,6 +1,6 @@
 {namespace vh=In2code\Powermail\ViewHelpers}
 <f:form.hidden
-		id="powermail_field_{field.marker}"
+		id="powermail_field_{field.marker}_{ttContentUid}"
 		property="{field.marker}"
 		value="{vh:misc.prefillField(field:field, mail:mail)}"
 		class="powermail_hidden {field.css} powermail_{field.marker}" />

--- a/Resources/Private/Partials/Form/Field/Input.html
+++ b/Resources/Private/Partials/Form/Field/Input.html
@@ -11,6 +11,6 @@
 				value="{vh:misc.prefillField(field:field, mail:mail)}"
 				class="powermail_input {settings.styles.framework.fieldClasses} {vh:validation.errorClass(field:field, class:'powermail_field_error')}"
 				additionalAttributes="{vh:validation.validationDataAttribute(field:field)}"
-				id="powermail_field_{field.marker}" />
+				id="powermail_field_{field.marker}_{ttContentUid}" />
 	</div>
 </div>

--- a/Resources/Private/Partials/Form/Field/Location.html
+++ b/Resources/Private/Partials/Form/Field/Location.html
@@ -5,7 +5,7 @@
 
 	<div class="{settings.styles.framework.fieldWrappingClasses}">
 		<f:form.textfield
-				id="powermail_field_{field.marker}"
+				id="powermail_field_{field.marker}_{ttContentUid}"
 				property="{field.marker}"
 				value="{vh:misc.prefillField(field:field, mail:mail)}"
 				additionalAttributes="{data-powermail-location:'prefill'}"

--- a/Resources/Private/Partials/Form/Field/Password.html
+++ b/Resources/Private/Partials/Form/Field/Password.html
@@ -5,7 +5,7 @@
 
 	<div class="{settings.styles.framework.fieldWrappingClasses}">
 		<f:form.password
-				id="powermail_field_{field.marker}"
+				id="powermail_field_{field.marker}_{ttContentUid}"
 				property="{field.marker}"
 				value=""
 				additionalAttributes="{vh:validation.validationDataAttribute(field:field)}"
@@ -15,17 +15,17 @@
 
 <div class="powermail_fieldwrap powermail_fieldwrap_type_password powermail_fieldwrap_{field.marker} powermail_fieldwrap_{field.marker}_mirror {field.css} {settings.styles.framework.fieldAndLabelWrappingClasses}">
 	<f:if condition="{field.css} != 'nolabel'">
-		<label for="powermail_field_{field.marker}_mirror" class="{settings.styles.framework.labelClasses}">
+		<label for="powermail_field_{field.marker}_{ttContentUid}_mirror" class="{settings.styles.framework.labelClasses}">
 			<f:translate key="writePasswordAgain" /><f:if condition="{field.mandatory}"><span class="mandatory">*</span></f:if>
 		</label>
 	</f:if>
 
 	<div class="{settings.styles.framework.fieldWrappingClasses}">
 		<f:form.password
-				id="powermail_field_{field.marker}_mirror"
+				id="powermail_field_{field.marker}_{ttContentUid}_mirror"
 				property="{field.marker}_mirror"
 				value=""
-				additionalAttributes="{vh:validation.passwordValidationDataAttribute(field:field)}"
+				additionalAttributes="{vh:validation.passwordValidationDataAttribute(field:field, ttContentUid:ttContentUid)}"
 				class="powermail_password {settings.styles.framework.fieldClasses} {vh:validation.errorClass(field:field, class:'powermail_field_error')}" />
 	</div>
 </div>

--- a/Resources/Private/Partials/Form/Field/Radio.html
+++ b/Resources/Private/Partials/Form/Field/Radio.html
@@ -11,7 +11,7 @@
 							property="{field.marker}"
 							value="{setting.value}"
 							checked="{vh:misc.prefillMultiField(field:field, mail:mail, cycle:index.cycle)}"
-							id="powermail_field_{field.marker}_{index.cycle}"
+							id="powermail_field_{field.marker}_{ttContentUid}_{index.cycle}"
 							additionalAttributes="{vh:validation.validationDataAttribute(field:field, iteration:index)}"
 							class="powermail_radio" />
 					<vh:string.escapeLabels>{setting.label}</vh:string.escapeLabels>

--- a/Resources/Private/Partials/Form/Field/Select.html
+++ b/Resources/Private/Partials/Form/Field/Select.html
@@ -8,7 +8,7 @@
 				options="{field.modifiedSettings}"
 				property="{field.marker}"
 				class="powermail_select {settings.styles.framework.fieldClasses} {vh:validation.errorClass(field:field, class:'powermail_field_error')}"
-				id="powermail_field_{field.marker}"
+				id="powermail_field_{field.marker}_{ttContentUid}"
 				additionalAttributes="{vh:validation.validationDataAttribute(field:field)}"
 				multiple="{field.multiselectForField}"
 				value="{vh:misc.prefillField(field:field, mail:mail)}" />

--- a/Resources/Private/Partials/Form/Field/Textarea.html
+++ b/Resources/Private/Partials/Form/Field/Textarea.html
@@ -7,7 +7,7 @@
 		<f:form.textarea
 				cols="20"
 				rows="5"
-				id="powermail_field_{field.marker}"
+				id="powermail_field_{field.marker}_{ttContentUid}"
 				property="{field.marker}"
 				placeholder="{field.placeholder}"
 				value="{vh:misc.prefillField(field:field, mail:mail)}"

--- a/Resources/Private/Partials/Form/FieldLabel.html
+++ b/Resources/Private/Partials/Form/FieldLabel.html
@@ -5,7 +5,7 @@
 </f:comment>
 
 <f:if condition="{field.css} != 'nolabel'">
-    <label for="powermail_field_{field.marker}" class="{settings.styles.framework.labelClasses}" title="{field.description}">
+    <label for="powermail_field_{field.marker}_{ttContentUid}" class="{settings.styles.framework.labelClasses}" title="{field.description}">
         <vh:string.escapeLabels>{field.title}</vh:string.escapeLabels><f:if condition="{field.mandatory}"><span class="mandatory">*</span></f:if>
     </label>
 </f:if>

--- a/Resources/Private/Partials/Form/Page.html
+++ b/Resources/Private/Partials/Form/Page.html
@@ -6,7 +6,7 @@
 
 	<f:for each="{page.fields}" as="field" iteration="iteration">
 		<vh:misc.createRowTags columns="{settings.styles.numberOfColumns}" class="{settings.styles.framework.rowClasses}" iteration="{iteration}">
-			<f:render partial="Form/Field/{vh:String.Upper(string:field.type)}" arguments="{field:field}" />
+			<f:render partial="Form/Field/{vh:String.Upper(string:field.type)}" arguments="{field:field, ttContentUid:ttContentData.uid}" />
 		</vh:misc.createRowTags>
 	</f:for>
 </fieldset>


### PR DESCRIPTION
Based on issue #181 the partials were modified, so that the id also includes the uid of the content element.

`id="powermail_field_{field.marker}_{ttContentUid}"`

It's possible to use multiple powermail forms with the same field names on the same page now.