### PR TITLE
[BUGFIX] Fixes "never reached localized form record UID" bug.

### DIFF
--- a/Classes/Tca/ShowFormNoteEditForm.php
+++ b/Classes/Tca/ShowFormNoteEditForm.php
@@ -119,9 +119,9 @@ class ShowFormNoteEditForm extends AbstractFormElement
     protected function getLocalizedFormUid(int $uid, int $sysLanguageUid): int
     {
         if ($sysLanguageUid > 0) {
-            $row = BackendUtilityCore::getRecordLocalization(Form::TABLE_NAME, (int)$uid, (int)$sysLanguageUid);
-            if (!empty($row['uid'])) {
-                $uid = (int)$row['uid'];
+            $results = BackendUtilityCore::getRecordLocalization(Form::TABLE_NAME, (int)$uid, (int)$sysLanguageUid);
+            if($results !== false && !empty($results[0]['uid'])) {
+                $uid = (int)$results[0]['uid'];
             }
         }
         return $uid;


### PR DESCRIPTION
If localized form record exists BackendUtilityCore::getRecordLocalization method will return array with one element which is an array of localized form data. Not the array of form data directly.
This fix solves the bug by fetching the first element in array and then get the UID of localized record.
$row is renamed to $results here. So, it should be "$results[0]['uid']" rather then "$results['uid']".