### PR TITLE
[TASK] respect sender.default.senderEmail for sender mail TO fallback

### DIFF
--- a/Classes/Domain/Repository/MailRepository.php
+++ b/Classes/Domain/Repository/MailRepository.php
@@ -386,7 +386,7 @@ class MailRepository extends AbstractRepository
             }
         }
         if (empty($email)) {
-            $email = $this->getSenderMailFromDefault($default);
+            $email = $this->getSenderMailFromSystemDefaults($default);
         }
         return $email;
     }
@@ -504,15 +504,12 @@ class MailRepository extends AbstractRepository
      * @param string $default
      * @return string
      */
-    protected function getSenderMailFromDefault(string $default): string
+    protected function getSenderMailFromSystemDefaults(string $default): string
     {
         $email = LocalizationUtility::translate('error_no_sender_email') . '@';
         $email .= str_replace('www.', '', GeneralUtility::getIndpEnv('TYPO3_HOST_ONLY'));
         if (GeneralUtility::validEmail(ConfigurationUtility::getDefaultMailFromAddress())) {
             $email = ConfigurationUtility::getDefaultMailFromAddress();
-        }
-        if (!empty($default)) {
-            $email = $default;
         }
         return $email;
     }

--- a/Classes/Domain/Repository/MailRepository.php
+++ b/Classes/Domain/Repository/MailRepository.php
@@ -361,10 +361,10 @@ class MailRepository extends AbstractRepository
      * Returns senderemail from a couple of arguments
      *
      * @param Mail $mail
-     * @param string $default
+     * @param string|array $default String as default or cObject array
      * @return string Sender Email
      */
-    public function getSenderMailFromArguments(Mail $mail, string $default = ''): string
+    public function getSenderMailFromArguments(Mail $mail, $default = null): string
     {
         $email = '';
         foreach ($mail->getAnswers() as $answer) {
@@ -374,6 +374,15 @@ class MailRepository extends AbstractRepository
             ) {
                 $email = trim($answer->getValue());
                 break;
+            }
+        }
+        if (empty($email)) {
+            if (!is_array($default)) {
+                $email = $default;
+            } else {
+                /** @var ContentObjectRenderer $contentObject */
+                $contentObject = ObjectUtility::getObjectManager()->get(ContentObjectRenderer::class);
+                $email = $contentObject->cObjGetSingle($default[0][$default[1]], $default[0][$default[1] . '.']);
             }
         }
         if (empty($email)) {

--- a/Classes/Domain/Repository/MailRepository.php
+++ b/Classes/Domain/Repository/MailRepository.php
@@ -376,7 +376,7 @@ class MailRepository extends AbstractRepository
                 break;
             }
         }
-        if (empty($email)) {
+        if (empty($email) && $default) {
             if (!is_array($default)) {
                 $email = $default;
             } else {
@@ -386,7 +386,7 @@ class MailRepository extends AbstractRepository
             }
         }
         if (empty($email)) {
-            $email = $this->getSenderMailFromSystemDefaults($default);
+            $email = $this->getSenderMailFromSystemDefaults();
         }
         return $email;
     }
@@ -501,10 +501,9 @@ class MailRepository extends AbstractRepository
     /**
      * Get sender default email address
      *
-     * @param string $default
      * @return string
      */
-    protected function getSenderMailFromSystemDefaults(string $default): string
+    protected function getSenderMailFromSystemDefaults(): string
     {
         $email = LocalizationUtility::translate('error_no_sender_email') . '@';
         $email .= str_replace('www.', '', GeneralUtility::getIndpEnv('TYPO3_HOST_ONLY'));

--- a/Classes/Domain/Service/Mail/SendSenderMailPreflight.php
+++ b/Classes/Domain/Service/Mail/SendSenderMailPreflight.php
@@ -68,7 +68,10 @@ class SendSenderMailPreflight
         $senderService = ObjectUtility::getObjectManager()->get(SenderMailPropertiesService::class, $this->settings);
         $email = [
             'template' => 'Mail/SenderMail',
-            'receiverEmail' => $this->mailRepository->getSenderMailFromArguments($mail),
+            'receiverEmail' => $this->mailRepository->getSenderMailFromArguments(
+                $mail,
+                [$this->conf['sender.']['default.'], 'senderEmail']
+            ),
             'receiverName' => $this->mailRepository->getSenderNameFromArguments(
                 $mail,
                 [$this->conf['sender.']['default.'], 'senderName']


### PR DESCRIPTION
In current powermail 8.4.1 I have a form with empty `settings.flexform.sender.email` (yay editors) and sender mail enabled. Now the email is send to the server admin email address (dunno taken from which setting yet).

For the recipient email I can define the
- FROM with `plugin.tx_powermail.settings.setup.receiver.default.senderEmail` and the
- TO with `plugin.tx_powermail.settings.setup.receiver.email`

For the sender email doing the same the
- FROM is `plugin.tx_powermail.settings.setup.sender.email` and
- `plugin.tx_powermail.settings.setup.sender.default.senderEmail` gets ignored thus the TO falls back to my server admin email address.

The code shows a lookup for `senderName` but not for `senderEmail`, thus I propose to copy that code for senderEmail, too.