### PR TITLE
[!!!][TASK] Make prefill work when a request is not cached, but caching is enabled

### DIFF
--- a/Classes/ViewHelpers/Misc/PrefillFieldViewHelper.php
+++ b/Classes/ViewHelpers/Misc/PrefillFieldViewHelper.php
@@ -379,7 +379,13 @@ class PrefillFieldViewHelper extends AbstractViewHelper
      */
     protected function isCachedForm(): bool
     {
-        return ConfigurationUtility::isEnableCachingActive()
+        $requestIsCached = true;
+        // as getControllerContext is not part of the RenderingContextInterface we have to check first
+        if (is_callable([$this->renderingContext, 'getControllerContext'])) {
+            $controllerContext = $this->renderingContext->getControllerContext();
+            $requestIsCached = $controllerContext->getRequest()->isCached();
+        }
+        return $requestIsCached && ConfigurationUtility::isEnableCachingActive()
             && ObjectUtility::getTyposcriptFrontendController()->no_cache !== true;
     }
 

--- a/Classes/ViewHelpers/Misc/PrefillMultiFieldViewHelper.php
+++ b/Classes/ViewHelpers/Misc/PrefillMultiFieldViewHelper.php
@@ -526,7 +526,13 @@ class PrefillMultiFieldViewHelper extends AbstractViewHelper
      */
     protected function isCachedForm(): bool
     {
-        return ConfigurationUtility::isEnableCachingActive()
+        $requestIsCached = true;
+        // as getControllerContext is not part of the RenderingContextInterface we have to check first
+        if (is_callable([$this->renderingContext, 'getControllerContext'])) {
+            $controllerContext = $this->renderingContext->getControllerContext();
+            $requestIsCached = $controllerContext->getRequest()->isCached();
+        }
+        return $requestIsCached && ConfigurationUtility::isEnableCachingActive()
             && ObjectUtility::getTyposcriptFrontendController()->no_cache !== true;
     }
 


### PR DESCRIPTION
Prefill cannot be used when caching is enabled even when it is safe to do so (because an action is called that is uncached).
This patch allowes using prefill when caching is enabled (good for situations with EXT:sfc & powermail forms that are included via Typoscript)