### PR TITLE
[BUGFIX] EvaluateEmail is never called

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -74,10 +74,9 @@ call_user_func(function () {
         In2code\Powermail\Hook\FlexFormManipulationHook::class;
 
     /**
-     * JavaScript evaluation of TCA fields
+     * JavaScript's evaluation of TCA fields
      */
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tce']['formevals']['\In2code\Powermail\Tca\EvaluateEmail'] =
-        'EXT:powermail/Classes/Tca/EvaluateEmail.php';
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tce']['formevals'][In2code\Powermail\Tca\EvaluateEmail::class] = '';
 
     /**
      * eID to get location from geo coordinates


### PR DESCRIPTION
Registration of the user defined form evaluations for email is false.
So the evaluation is never tested during the editing process.