### PR TITLE
Update PreventDuplicates.md

### DIFF
--- a/Documentation/ForAdministrators/BestPractice/PreventDuplicates.md
+++ b/Documentation/ForAdministrators/BestPractice/PreventDuplicates.md
@@ -100,7 +100,7 @@ See a possible solution for an inline JavaScript in the Submit-Partial of powerm
             elements.forEach(function(element) {
                 element.addEventListener('click', function(event) {
                     submitAmount++;
-                    if (submitAmount > 1) {
+                    if (submitAmount >= 1) {
                         event.target.disabled = true;
                         setTimeout(
                             function() {


### PR DESCRIPTION
Updated the JavaScript to prevent duplicates with clientside technology. With "submitAmout > 1" it is still possible to submit the form 2 times within 6000 ms. Changing the operator to ">=" the form can only submitted 1 time within 6000 ms.