### PR TITLE
[BUGFIX] Handle lookup of properties of non-existing page

### DIFF
--- a/Classes/Domain/Repository/PageRepository.php
+++ b/Classes/Domain/Repository/PageRepository.php
@@ -39,7 +39,8 @@ class PageRepository extends AbstractRepository
     public function getPropertiesFromUid(int $uid): array
     {
         $connection = DatabaseUtility::getConnectionForTable('pages');
-        return $connection->executeQuery('select * from pages where uid=' . (int)$uid . ' limit 1')->fetchAssociative();
+        $properties = $connection->executeQuery('select * from pages where uid=' . (int)$uid . ' limit 1')->fetchAssociative();
+        return $properties ?: [];
     }
 
     /**

--- a/Classes/Tca/FormSelectorUserFunc.php
+++ b/Classes/Tca/FormSelectorUserFunc.php
@@ -163,7 +163,9 @@ class FormSelectorUserFunc
     {
         if (!$this->hasFullAccess()) {
             $properties = $this->pageRepository->getPropertiesFromUid($pageIdentifier);
-            return BackendUtility::getBackendUserAuthentication()->doesUserHaveAccess($properties, 1);
+            if ($properties !== []) {
+                return BackendUtility::getBackendUserAuthentication()->doesUserHaveAccess($properties, 1);
+            }
         }
         return true;
     }


### PR DESCRIPTION
This PR fixes a bug inside `PageRepository::getPropertiesFromUid()` when a non-existent page is queried. In this case, the result is `false` instead of an array. This was already addressed with 618f5ec804063c03c9bb9feb3591b2d742460705, but is obviously missing in more recent versions of the extension.

Resolves: #874