### PR TITLE
Added return type to PowermailConditionFunctionsProvider::getFunctions()

### DIFF
--- a/Classes/Condition/PowermailConditionFunctionsProvider.php
+++ b/Classes/Condition/PowermailConditionFunctionsProvider.php
@@ -17,7 +17,7 @@ class PowermailConditionFunctionsProvider implements ExpressionFunctionProviderI
     /**
      * @return array|ExpressionFunction[]
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             $this->isPowermailPluginOnCurrentPageFunction(),


### PR DESCRIPTION
Added return type to `PowermailConditionFunctionsProvider::getFunctions()` due to
```
Fatal error: Declaration of In2code\Powermail\Condition\PowermailConditionFunctionsProvider::getFunctions() must be compatible with Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface::getFunctions(): array in /var/www/html/htdocs/vendor/in2code/powermail/Classes/Condition/PowermailConditionFunctionsProvider.php on line 20
```