### PR TITLE
[BUGFIX] Fix broken manipulateVariablesInPowermailAllMarker for arrays

### DIFF
--- a/Classes/ViewHelpers/Misc/ManipulateValueWithTypoScriptViewHelper.php
+++ b/Classes/ViewHelpers/Misc/ManipulateValueWithTypoScriptViewHelper.php
@@ -61,7 +61,16 @@ class ManipulateValueWithTypoScriptViewHelper extends AbstractViewHelper
             if (
                 isset($this->typeToTsType[$type]) &&
                 !empty($this->typoScriptContext[$this->typeToTsType[$type] . '.'][$answer->getField()->getMarker()])) {
-                $this->contentObjectRenderer->start($answer->_getProperties());
+                $properties = ['value' => $value];
+                if ($answer->getField()->getSettings()) {
+                    $settings = $answer->getField()->getModifiedSettings();
+                    $settings = array_combine(
+                        array_column($settings, 'value'),
+                        array_column($settings, 'label')
+                    );
+                    $properties['label'] = $settings[$value] ?? $value;
+                }
+                $this->contentObjectRenderer->start($properties);
                 $value = $this->contentObjectRenderer->cObjGetSingle(
                     $this->typoScriptContext[$this->typeToTsType[$type] . '.'][$answer->getField()->getMarker()],
                     $this->typoScriptContext[$this->typeToTsType[$type] . '.'][$answer->getField()->getMarker() . '.']

--- a/Documentation/ForAdministrators/BestPractice/ManipulateValuesFromPowermailAll.md
+++ b/Documentation/ForAdministrators/BestPractice/ManipulateValuesFromPowermailAll.md
@@ -31,76 +31,76 @@ plugin.tx_powermail {
             manipulateVariablesInPowermailAllMarker {
                 # On Confirmation Page (if activated)
                 confirmationPage {
-                    # manipulate values by given marker (e.g. firstname, email, referrer) with TypoScript - available fieldnames (access with .field=): value, valueType, uid, pid
+                    # manipulate values by given marker (e.g. firstname, email, referrer) with TypoScript - available fieldnames (access with .field=): value, label
                     markerName = CASE
                     markerName {
                         key.field = value
 
                         1 = TEXT
-                        1.value = red
+                        1.value = Override for value 1
 
                         default = TEXT
-                        default.value = blue
+                        default.field = label
                     }
                 }
 
                 # On Submitpage
                 submitPage {
-                    # manipulate values by given marker (e.g. firstname, email, referrer) with TypoScript - available fieldnames (access with .field=): value, valueType, uid, pid
+                    # manipulate values by given marker (e.g. firstname, email, referrer) with TypoScript - available fieldnames (access with .field=): value, label
                     markerName = CASE
                     markerName {
                         key.field = value
 
                         1 = TEXT
-                        1.value = red
+                        1.value = Override for value 1
 
                         default = TEXT
-                        default.value = blue
+                        default.field = label
                     }
                 }
 
                 # In Mail to receiver
                 receiverMail {
-                    # manipulate values by given marker (e.g. firstname, email, referrer) with TypoScript - available fieldnames (access with .field=): value, valueType, uid, pid
+                    # manipulate values by given marker (e.g. firstname, email, referrer) with TypoScript - available fieldnames (access with .field=): value, label
                     markerName = CASE
                     markerName {
                         key.field = value
 
                         1 = TEXT
-                        1.value = red
+                        1.value = Override for value 1
 
                         default = TEXT
-                        default.value = blue
+                        default.field = label
                     }
                 }
 
                 # In Mail to sender (if activated)
                 senderMail {
-                    # manipulate values by given marker (e.g. firstname, email, referrer) with TypoScript - available fieldnames (access with .field=): value, valueType, uid, pid
+                    # manipulate values by given marker (e.g. firstname, email, referrer) with TypoScript - available fieldnames (access with .field=): value, label
                     markerName = CASE
                     markerName {
                         key.field = value
 
                         1 = TEXT
-                        1.value = red
+                        1.value = Override for value 1
 
                         default = TEXT
-                        default.value = blue
+                        default.field = label
                     }
                 }
 
                 # In double-opt-in Mail to sender (if activated)
                 optinMail {
-                    # manipulate values by given marker (e.g. firstname, email, referrer) with TypoScript - available fieldnames (access with .field=): value, valueType, uid, pid
+                    # manipulate values by given marker (e.g. firstname, email, referrer) with TypoScript - available fieldnames (access with .field=): value, label
                     markerName = CASE
                     markerName {
                         key.field = value
 
                         1 = TEXT
-                        1.value = red
+                        1.value = Override for value 1
 
                         default = TEXT
-                        default.value = blue
+                        default.field = label
                     }
                 }
             }


### PR DESCRIPTION
Without this patch it's not possible to use `manipulateVariablesInPowermailAllMarker` to manipulate selected values of an array field such as checkboxes and multiselect.

Additionally it's now possible to access an options label as defined in a fields settings.
    
Example:
    

    plugin.tx_powermail.settings.setup {
        manipulateVariablesInPowermailAllMarker {
            optinMail {
                my_checkboxes = CASE
                my_checkboxes {
                    key.field = value
                    # Override label for option 1
                    1 = TEXT
                    1.value = Override for option value 1
                    # Use label for other field option
                    default = TEXT
                    default.field = label
                }
            }
        }
    }

This patch can be backported to `10.7.x` too.

Resolves: #956