### PR TITLE
[DOCS] Fix markdown syntax errors

### DIFF
--- a/Documentation/FAQ/Readme.md
+++ b/Documentation/FAQ/Readme.md
@@ -57,11 +57,11 @@ How does the magic work? There is a viewhelper in Page.html partial, that adds c
 </vh:misc.createRowTags>
 ```
 
-columns:              Number of columns - 0 disables creation of new containers completely
-class:                Class name(s) for the new tag
-iteration:            The iteration array from a foreach viewhelper
-additionalAttributes: Any additional attributes for the new tags (must be type of array)
-tagName:              Tagname for the new containers ("div" if not given)
+- `columns`: Number of columns - 0 disables creation of new containers completely
+- `class`: Class name(s) for the new tag
+- `iteration`: The iteration array from a foreach viewhelper
+- `additionalAttributes`: Any additional attributes for the new tags (must be type of array)
+- `tagName`: Tagname for the new containers ("div" if not given)
 
 
 ## How to solve SPF defiance?

--- a/Documentation/ForAdministrators/BestPractice/DevelopmentContext.md
+++ b/Documentation/ForAdministrators/BestPractice/DevelopmentContext.md
@@ -1,6 +1,6 @@
 # Development Context
 
-It could be usefull to set a test receiver email for all powermail forms in one TYPO3 instance.
+It could be useful to set a test receiver email for all powermail forms in one TYPO3 instance.
 
 Together with the context mode (introduced in TYPO3 6.2) you can test your forms on your development environment
 and deploy it to a production server without making changes in the database.

--- a/Documentation/ForAdministrators/Installation.md
+++ b/Documentation/ForAdministrators/Installation.md
@@ -43,6 +43,7 @@ Add powermail static templates for full functions
 ![static_templates](../Images/static_templates.png)
 
 | Field | Description |
+| ----- | ----------- |
 | Main template (powermail) | Main functions and settings for all powermail forms. |
 | Powermail_Frontend (powermail) | If you want to use show mails in frontend (Pi2), choose this template. |
 | Add classes and CSS based on bootstrap (powermail) | If you want to add default bootstrap classes to all forms, pages and fields in frontend, you should add this static template. Note: If you want to add bootstrap.css from powermail, see constant editor. |

--- a/Documentation/ForAdministrators/Upgrade.md
+++ b/Documentation/ForAdministrators/Upgrade.md
@@ -1,4 +1,4 @@
-y# Upgrade Powermail
+# Upgrade Powermail
 
 ## Introduction
 

--- a/Documentation/ForDevelopers/AddNewFieldProperties.md
+++ b/Documentation/ForDevelopers/AddNewFieldProperties.md
@@ -5,9 +5,9 @@
 You can extend powermail fields with new properties to insert (e.g.) a checkbox for readonly or disabled or
 something else.
 
-Following example shows two new fields in a new tab "Powermailextended".  
+Following example shows two new fields in a new tab "Powermailextended".
 The first is an input field of type textarea. If the user entered text for this field this text shall
-be displayed.  
+be displayed.
 The second field is a checkbox. If this checkbox was checked from an editor, the input field should use
 the html-attribute readonly="readonly".
 
@@ -336,8 +336,7 @@ class FormRepository extends \In2code\Powermail\Domain\Repository\FormRepository
 
 Last but not least don't forget to add your static TypoScript template to your powermail page, otherwise the partials will not be used.
 
-Example Code
-""""""""""""
+## Example Code
 
 Look at https://github.com/einpraegsam/powermailextended for an example extension.
 This extension allows you to:

--- a/Documentation/ForDevelopers/AddSpamshieldMethods.md
+++ b/Documentation/ForDevelopers/AddSpamshieldMethods.md
@@ -162,8 +162,7 @@ class SpamPreventionMethod extends AbstractMethod
 ```
 
 
-Some notices
-""""""""""""
+## Some notices
 
 * Method spamCheck() will be called always
 * The method initialize() and initializeSpamCheck() will always be called at first

--- a/Documentation/ForDevelopers/DisableSpamshield.md
+++ b/Documentation/ForDevelopers/DisableSpamshield.md
@@ -188,8 +188,7 @@ class IpBreaker extends AbstractBreaker
 ```
 
 
-Some notices
-""""""""""""
+## Some notices
 
 * You have to add the method isDisabled() and you have to return a boolean value
 * The method initialize() will always be called at first

--- a/Documentation/ForDevelopers/EventDispatcher.md
+++ b/Documentation/ForDevelopers/EventDispatcher.md
@@ -7,7 +7,7 @@ extend functions and properties with your extension.
 Please report to https://github.com/einpraegsam/powermail/issues if you need a new event anywhere.
 
 | Location | Event | Description |
-|-------------------|-------------|-------------------|------------------|-------------|
+| -------- | ----- | ----------- |
 | `In2code\Powermail\Domain\Validator\CustomValidator::isValid()` | `In2code\Powermail\Events\CustomValidatorEvent` | Add your own serverside Validation |
 | `In2code\Powermail\Controller\FormController::formAction()` | `In2code\Powermail\Events\FormControllerFormActionEvent` | Listeners are called before the form is rendered |
 | `In2code\Powermail\Controller\FormController::createAction()` | `In2code\Powermail\Events\FormControllerCreateActionBeforeRenderViewEvent` | Listeners are called before the mail and answers are persisted and before the emails are sent |
@@ -40,7 +40,6 @@ There is a very good documentation how to work with EventDispatcher in TYPO3:
 https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Events/EventDispatcher/Index.html
 
 ### Example Code
-""""""""""""
 
 Look at https://github.com/einpraegsam/powermailextended for an example extension.
 This extension allows you to:


### PR DESCRIPTION
Some seem to be leftovers of reStructuredText,
some tables are broken
and a typo is also fixed.