### PR TITLE
[BUGFIX] Check for `isMailPersistActive` before persisting

### DIFF
--- a/Classes/Controller/FormController.php
+++ b/Classes/Controller/FormController.php
@@ -265,7 +265,7 @@ class FormController extends AbstractController
             $mailPreflight->sendOptinConfirmationMail($mail);
             $this->view->assign('optinActive', true);
         }
-        if ($this->isPersistActive() && $isSavingOfMailAllowed) {
+        if ($this->isMailPersistActive($hash) && $isSavingOfMailAllowed) {
             $this->mailRepository->update($mail);
             $this->persistenceManager->persistAll();
         }


### PR DESCRIPTION
Persisting a mail should also be done if it's an opt-in. The formerly used `isPersistActive()` does not cover this case. Therefore, `$isSavingOfMailAllowed` was undefined in this case.

Fixes: #958