### PR TITLE
[BUGFIX] Pages and fields cannot be found in list module search

### DIFF
--- a/Configuration/TCA/tx_powermail_domain_model_field.php
+++ b/Configuration/TCA/tx_powermail_domain_model_field.php
@@ -227,6 +227,7 @@ $fieldsTca = [
             'endtime' => 'endtime',
         ],
         'iconfile' => ConfigurationUtility::getIconPath(Field::TABLE_NAME . '.gif'),
+        'searchFields' => 'title',
     ],
     'interface' => [
     ],

--- a/Configuration/TCA/tx_powermail_domain_model_page.php
+++ b/Configuration/TCA/tx_powermail_domain_model_page.php
@@ -26,6 +26,7 @@ $pagesTca = [
             'endtime' => 'endtime',
         ],
         'iconfile' => ConfigurationUtility::getIconPath(Page::TABLE_NAME . '.gif'),
+        'searchFields' => 'title',
     ],
     'interface' => [
     ],


### PR DESCRIPTION
Due to missing `searchFields` in page and field TCA it's current not possible to find those records by their title via list modules own search. This patch fixes that.

![image](https://github.com/in2code-de/powermail/assets/1405149/d72abeae-73a1-4172-b399-086f7c536a88)
