### PR TITLE
[BUGFIX] Fixed query to check if a field has values

### DIFF
--- a/Classes/Utility/DatabaseUtility.php
+++ b/Classes/Utility/DatabaseUtility.php
@@ -107,7 +107,7 @@ class DatabaseUtility
                     ->from($tableName)
                     ->where($fieldName . ' != "" and ' . $fieldName . ' != 0')
                     ->executeQuery()
-                    ->rowCount() > 0;
+                    ->fetchOne() > 0;
         }
         return false;
     }


### PR DESCRIPTION
The rowCount() is never <= 0, even if the count result is 0. Due to this bug, the upgrade wizard does not display the task to update "pages" to "page" and "forms" to "form" when upgrading from TYPO3 9 or earlier to version 12.