### PR TITLE
[BUGFIX] Use fetchOne to retrieve the first value to prevent array to string cast

### DIFF
--- a/Classes/Domain/Repository/FieldRepository.php
+++ b/Classes/Domain/Repository/FieldRepository.php
@@ -254,6 +254,6 @@ class FieldRepository extends AbstractRepository
             ->where('uid=' . (int)$uid)
             ->setMaxResults(1)
             ->executeQuery()
-            ->fetchAssociative();
+            ->fetchOne();
     }
 }


### PR DESCRIPTION
Error: 

`PHP Warning: Array to string conversion in powermail/Classes/Domain/Repository/FieldRepository.php line 257`

Solution:
`return (string)$queryBuilder->select('type')->[...]->fetchAssociative();` 
`return (string)$queryBuilder->select('type')->[...]->fetchOne();` 

Resolves: https://projekte.in2code.de/issues/62775