### PR TITLE
Spam log files should use append and not prepend

### DIFF
--- a/Classes/Domain/Validator/SpamShieldValidator.php
+++ b/Classes/Domain/Validator/SpamShieldValidator.php
@@ -204,7 +204,7 @@ class SpamShieldValidator extends AbstractValidator
                 $this->settings['spamshield']['logTemplate'],
                 $this->getVariablesForSpamNotification($mail)
             );
-            BasicFileUtility::prependContentToFile($this->settings['spamshield']['logfileLocation'], $logMessage);
+            BasicFileUtility::appendContentToFile($this->settings['spamshield']['logfileLocation'], $logMessage);
         }
     }
 

--- a/Classes/Utility/BasicFileUtility.php
+++ b/Classes/Utility/BasicFileUtility.php
@@ -61,6 +61,24 @@ class BasicFileUtility
     }
 
     /**
+     * Append content to the end of a file
+     *
+     * @param string $pathAndFile
+     * @param string $content
+     * @return void
+     */
+    public static function appendContentToFile(string $pathAndFile, string $content): void
+    {
+        $absolutePathAndFile = GeneralUtility::getFileAbsFileName($pathAndFile);
+        $lines = [];
+        if (is_file($absolutePathAndFile)) {
+            $lines = file($absolutePathAndFile);
+        }
+        array_push($lines, $content);
+        GeneralUtility::writeFile($absolutePathAndFile, implode('', $lines));
+    }
+
+    /**
      * Prepend content to the beginning of a file
      *
      * @param string $pathAndFile


### PR DESCRIPTION
I wanted to switch spam logging to file based and logrotate and stumbled over powermail using prepend instead of append.

For me this seems like a surprise legacy decision (Feature created 9 years ago with that choice: https://github.com/in2code-de/powermail/commit/a678086d9a14bd58c06173c470527d2cf8f40b2e) which wouldn't be done today, as logs typically append.

Of course I might overlook stuff and of course this is breaking, but IMHO could be considered.