### PR TITLE
[TASK] Remove deprecated TCEforms FlexForm tag

### DIFF
--- a/Configuration/FlexForms/FlexformPi1.xml
+++ b/Configuration/FlexForms/FlexformPi1.xml
@@ -5,334 +5,285 @@
 	<sheets>
 		<main>
 			<ROOT>
-				<TCEforms>
-					<sheetTitle>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.main</sheetTitle>
-				</TCEforms>
+				<sheetTitle>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.main</sheetTitle>
 				<type>array</type>
 				<el>
 					<settings.flexform.main.form>
-						<TCEforms>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.main.form</label>
-							<config>
-								<type>select</type>
-								<renderType>selectSingle</renderType>
-								<items type="array">
-
-								</items>
-								<size>1</size>
-								<minitems>1</minitems>
-								<maxitems>1</maxitems>
-								<wizards>
-									<suggest>
-										<title>Add Form</title>
-										<type>suggest</type>
-									</suggest>
-								</wizards>
-								<itemsProcFunc>In2code\Powermail\Tca\FormSelectorUserFunc->getForms</itemsProcFunc>
-							</config>
-						</TCEforms>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.main.form</label>
+						<config>
+							<type>select</type>
+							<renderType>selectSingle</renderType>
+							<items type="array">
+							</items>
+							<size>1</size>
+							<minitems>1</minitems>
+							<maxitems>1</maxitems>
+							<wizards>
+								<suggest>
+									<title>Add Form</title>
+									<type>suggest</type>
+								</suggest>
+							</wizards>
+							<itemsProcFunc>In2code\Powermail\Tca\FormSelectorUserFunc->getForms</itemsProcFunc>
+						</config>
 					</settings.flexform.main.form>
 					<settings.flexform.main.formnote>
-						<TCEforms>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.main.formnote</label>
-							<config>
-								<type>user</type>
-								<renderType>powermailShowFormNoteEditForm</renderType>
-							</config>
-						</TCEforms>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.main.formnote</label>
+						<config>
+							<type>user</type>
+							<renderType>powermailShowFormNoteEditForm</renderType>
+						</config>
 					</settings.flexform.main.formnote>
 					<settings.flexform.main.confirmation>
-						<TCEforms>
-							<exclude>1</exclude>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.main.confirmation</label>
-							<config>
-								<type>check</type>
-								<default>0</default>
-							</config>
-						</TCEforms>
+						<exclude>1</exclude>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.main.confirmation</label>
+						<config>
+							<type>check</type>
+							<default>0</default>
+						</config>
 					</settings.flexform.main.confirmation>
 					<settings.flexform.main.optin>
-						<TCEforms>
-							<exclude>1</exclude>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.main.optin</label>
-							<config>
-								<type>check</type>
-								<default>0</default>
-							</config>
-						</TCEforms>
+						<exclude>1</exclude>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.main.optin</label>
+						<config>
+							<type>check</type>
+							<default>0</default>
+						</config>
 					</settings.flexform.main.optin>
 					<settings.flexform.main.moresteps>
-						<TCEforms>
-							<exclude>1</exclude>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.main.moresteps</label>
-							<config>
-								<type>check</type>
-								<default>0</default>
-							</config>
-						</TCEforms>
+						<exclude>1</exclude>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.main.moresteps</label>
+						<config>
+							<type>check</type>
+							<default>0</default>
+						</config>
 					</settings.flexform.main.moresteps>
 					<settings.flexform.main.pid>
-						<TCEforms>
-							<exclude>1</exclude>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.main.pid</label>
-							<config>
-								<type>group</type>
-								<internal_type>db</internal_type>
-								<allowed>pages</allowed>
-								<size>1</size>
-								<maxitems>1</maxitems>
-								<minitems>0</minitems>
-								<show_thumbs>1</show_thumbs>
-							</config>
-						</TCEforms>
+						<exclude>1</exclude>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.main.pid</label>
+						<config>
+							<type>group</type>
+							<internal_type>db</internal_type>
+							<allowed>pages</allowed>
+							<size>1</size>
+							<maxitems>1</maxitems>
+							<minitems>0</minitems>
+							<show_thumbs>1</show_thumbs>
+						</config>
 					</settings.flexform.main.pid>
 				</el>
 			</ROOT>
 		</main>
 		<receiver>
 			<ROOT>
-				<TCEforms>
-					<sheetTitle>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver</sheetTitle>
-				</TCEforms>
+				<sheetTitle>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver</sheetTitle>
 				<type>array</type>
 				<el>
 					<settings.flexform.receiver.type>
-						<TCEforms>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.type</label>
-							<onChange>reload</onChange>
-							<config>
-								<type>select</type>
-								<renderType>selectSingle</renderType>
-								<items type="array">
-									<numIndex index="0" type="array">
-										<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.type.0</numIndex>
-										<numIndex index="1">0</numIndex>
-									</numIndex>
-									<numIndex index="1" type="array">
-										<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.type.1</numIndex>
-										<numIndex index="1">1</numIndex>
-									</numIndex>
-									<numIndex index="3" type="array">
-										<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.type.3</numIndex>
-										<numIndex index="1">3</numIndex>
-									</numIndex>
-									<numIndex index="2" type="array">
-										<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.type.2</numIndex>
-										<numIndex index="1">2</numIndex>
-									</numIndex>
-								</items>
-								<size>1</size>
-								<minitems>1</minitems>
-								<maxitems>1</maxitems>
-							</config>
-						</TCEforms>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.type</label>
+						<onChange>reload</onChange>
+						<config>
+							<type>select</type>
+							<renderType>selectSingle</renderType>
+							<items type="array">
+								<numIndex index="0" type="array">
+									<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.type.0</numIndex>
+									<numIndex index="1">0</numIndex>
+								</numIndex>
+								<numIndex index="1" type="array">
+									<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.type.1</numIndex>
+									<numIndex index="1">1</numIndex>
+								</numIndex>
+								<numIndex index="3" type="array">
+									<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.type.3</numIndex>
+									<numIndex index="1">3</numIndex>
+								</numIndex>
+								<numIndex index="2" type="array">
+									<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.type.2</numIndex>
+									<numIndex index="1">2</numIndex>
+								</numIndex>
+							</items>
+							<size>1</size>
+							<minitems>1</minitems>
+							<maxitems>1</maxitems>
+						</config>
 					</settings.flexform.receiver.type>
 					<settings.flexform.receiver.name>
-						<TCEforms>
-							<exclude>1</exclude>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.name</label>
-							<config>
-								<type>input</type>
-								<eval>trim</eval>
-							</config>
-						</TCEforms>
+						<exclude>1</exclude>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.name</label>
+						<config>
+							<type>input</type>
+							<eval>trim</eval>
+						</config>
 					</settings.flexform.receiver.name>
 					<settings.flexform.receiver.email>
-						<TCEforms>
-							<exclude>1</exclude>
-							<displayCond>
-								<AND>
-									<numIndex index="0">FIELD:settings.flexform.receiver.type:!=:1</numIndex>
-									<numIndex index="1">FIELD:settings.flexform.receiver.type:!=:2</numIndex>
-									<numIndex index="2">FIELD:settings.flexform.receiver.type:!=:3</numIndex>
-								</AND>
-							</displayCond>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.email</label>
-							<config>
-								<type>text</type>
-								<cols>32</cols>
-								<rows>2</rows>
-							</config>
-						</TCEforms>
+						<exclude>1</exclude>
+						<displayCond>
+							<AND>
+								<numIndex index="0">FIELD:settings.flexform.receiver.type:!=:1</numIndex>
+								<numIndex index="1">FIELD:settings.flexform.receiver.type:!=:2</numIndex>
+								<numIndex index="2">FIELD:settings.flexform.receiver.type:!=:3</numIndex>
+							</AND>
+						</displayCond>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.email</label>
+						<config>
+							<type>text</type>
+							<cols>32</cols>
+							<rows>2</rows>
+						</config>
 					</settings.flexform.receiver.email>
 					<settings.flexform.receiver.fe_group>
-						<TCEforms>
-							<exclude>1</exclude>
-							<displayCond>FIELD:settings.flexform.receiver.type:=:1</displayCond>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.fe_group</label>
-							<config>
-								<type>select</type>
-								<renderType>selectSingle</renderType>
-								<items type="array">
-									<numIndex index="0" type="array">
-										<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:pleaseChoose</numIndex>
-										<numIndex index="1"></numIndex>
-									</numIndex>
-								</items>
-								<maxitems>1</maxitems>
-								<size>1</size>
-								<minitems>0</minitems>
-								<selectedListStyle>width:300px;</selectedListStyle>
-								<itemListStyle>width:300px;</itemListStyle>
-								<foreign_table>fe_groups</foreign_table>
-								<foreign_table_where>AND fe_groups.deleted = 0 AND fe_groups.hidden = 0 order by fe_groups.title</foreign_table_where>
-							</config>
-						</TCEforms>
+						<exclude>1</exclude>
+						<displayCond>FIELD:settings.flexform.receiver.type:=:1</displayCond>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.fe_group</label>
+						<config>
+							<type>select</type>
+							<renderType>selectSingle</renderType>
+							<items type="array">
+								<numIndex index="0" type="array">
+									<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:pleaseChoose</numIndex>
+									<numIndex index="1"></numIndex>
+								</numIndex>
+							</items>
+							<maxitems>1</maxitems>
+							<size>1</size>
+							<minitems>0</minitems>
+							<selectedListStyle>width:300px;</selectedListStyle>
+							<itemListStyle>width:300px;</itemListStyle>
+							<foreign_table>fe_groups</foreign_table>
+							<foreign_table_where>AND fe_groups.deleted = 0 AND fe_groups.hidden = 0 order by fe_groups.title</foreign_table_where>
+						</config>
 					</settings.flexform.receiver.fe_group>
 					<settings.flexform.receiver.be_group>
-						<TCEforms>
-							<exclude>1</exclude>
-							<displayCond>FIELD:settings.flexform.receiver.type:=:3</displayCond>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.be_group</label>
-							<config>
-								<type>select</type>
-								<renderType>selectSingle</renderType>
-								<items type="array">
-									<numIndex index="0" type="array">
-										<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:pleaseChoose</numIndex>
-										<numIndex index="1"></numIndex>
-									</numIndex>
-								</items>
-								<maxitems>1</maxitems>
-								<size>1</size>
-								<minitems>0</minitems>
-								<selectedListStyle>width:300px;</selectedListStyle>
-								<itemListStyle>width:300px;</itemListStyle>
-								<foreign_table>be_groups</foreign_table>
-								<foreign_table_where>AND be_groups.deleted = 0 AND be_groups.hidden = 0 order by be_groups.title</foreign_table_where>
-							</config>
-						</TCEforms>
+						<exclude>1</exclude>
+						<displayCond>FIELD:settings.flexform.receiver.type:=:3</displayCond>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.be_group</label>
+						<config>
+							<type>select</type>
+							<renderType>selectSingle</renderType>
+							<items type="array">
+								<numIndex index="0" type="array">
+									<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:pleaseChoose</numIndex>
+									<numIndex index="1"></numIndex>
+								</numIndex>
+							</items>
+							<maxitems>1</maxitems>
+							<size>1</size>
+							<minitems>0</minitems>
+							<selectedListStyle>width:300px;</selectedListStyle>
+							<itemListStyle>width:300px;</itemListStyle>
+							<foreign_table>be_groups</foreign_table>
+							<foreign_table_where>AND be_groups.deleted = 0 AND be_groups.hidden = 0 order by be_groups.title</foreign_table_where>
+						</config>
 					</settings.flexform.receiver.be_group>
 					<settings.flexform.receiver.predefinedemail>
-						<TCEforms>
-							<exclude>1</exclude>
-							<displayCond>FIELD:settings.flexform.receiver.type:=:2</displayCond>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.predefinedemail</label>
-							<config>
-								<type>select</type>
-								<renderType>selectSingle</renderType>
-								<items type="array">
-									<numIndex index="0" type="array">
-										<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:pleaseChoose</numIndex>
-										<numIndex index="1"></numIndex>
-									</numIndex>
-								</items>
-								<size>1</size>
-								<minitems>1</minitems>
-								<maxitems>1</maxitems>
-								<itemsProcFunc>In2code\Powermail\Tca\AddOptionsToSelection->addOptionsForPredefinedReceivers</itemsProcFunc>
-							</config>
-						</TCEforms>
+						<exclude>1</exclude>
+						<displayCond>FIELD:settings.flexform.receiver.type:=:2</displayCond>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.predefinedemail</label>
+						<config>
+							<type>select</type>
+							<renderType>selectSingle</renderType>
+							<items type="array">
+								<numIndex index="0" type="array">
+									<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:pleaseChoose</numIndex>
+									<numIndex index="1"></numIndex>
+								</numIndex>
+							</items>
+							<size>1</size>
+							<minitems>1</minitems>
+							<maxitems>1</maxitems>
+							<itemsProcFunc>In2code\Powermail\Tca\AddOptionsToSelection->addOptionsForPredefinedReceivers</itemsProcFunc>
+						</config>
 					</settings.flexform.receiver.predefinedemail>
 					<settings.flexform.receiver.subject>
-						<TCEforms>
-							<exclude>1</exclude>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.subject</label>
-							<config>
-								<type>input</type>
-								<eval>trim</eval>
-							</config>
-						</TCEforms>
+						<exclude>1</exclude>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.subject</label>
+						<config>
+							<type>input</type>
+							<eval>trim</eval>
+						</config>
 					</settings.flexform.receiver.subject>
 					<settings.flexform.receiver.body>
-						<TCEforms>
-							<exclude>1</exclude>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.body</label>
-							<config>
-								<type>text</type>
-								<default>{powermail_all}</default>
-								<enableRichtext>1</enableRichtext>
-								<richtextConfiguration>default</richtextConfiguration>
-							</config>
-							<defaultExtras>richtext[]:rte_transform[mode=ts_css]</defaultExtras>
-						</TCEforms>
+						<exclude>1</exclude>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.body</label>
+						<config>
+							<type>text</type>
+							<default>{powermail_all}</default>
+							<enableRichtext>1</enableRichtext>
+							<richtextConfiguration>default</richtextConfiguration>
+						</config>
+						<defaultExtras>richtext[]:rte_transform[mode=ts_css]</defaultExtras>
 					</settings.flexform.receiver.body>
 				</el>
 			</ROOT>
 		</receiver>
 		<sender>
 			<ROOT>
-				<TCEforms>
-					<sheetTitle>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.sender</sheetTitle>
-				</TCEforms>
+				<sheetTitle>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.sender</sheetTitle>
 				<type>array</type>
 				<el>
 					<settings.flexform.sender.name>
-						<TCEforms>
-							<exclude>1</exclude>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.sender.name</label>
-							<config>
-								<type>input</type>
-								<eval>trim</eval>
-							</config>
-						</TCEforms>
+						<exclude>1</exclude>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.sender.name</label>
+						<config>
+							<type>input</type>
+							<eval>trim</eval>
+						</config>
 					</settings.flexform.sender.name>
 					<settings.flexform.sender.email>
-						<TCEforms>
-							<exclude>1</exclude>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.sender.email</label>
-							<config>
-								<type>input</type>
-								<eval>trim,In2code\Powermail\Tca\EvaluateEmail</eval>
-							</config>
-						</TCEforms>
+						<exclude>1</exclude>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.sender.email</label>
+						<config>
+							<type>input</type>
+							<eval>trim,In2code\Powermail\Tca\EvaluateEmail</eval>
+						</config>
 					</settings.flexform.sender.email>
 					<settings.flexform.sender.subject>
-						<TCEforms>
-							<exclude>1</exclude>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.sender.subject</label>
-							<config>
-								<type>input</type>
-								<eval>trim</eval>
-							</config>
-						</TCEforms>
+						<exclude>1</exclude>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.sender.subject</label>
+						<config>
+							<type>input</type>
+							<eval>trim</eval>
+						</config>
 					</settings.flexform.sender.subject>
 					<settings.flexform.sender.body>
-						<TCEforms>
-							<exclude>1</exclude>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.sender.body</label>
-							<config>
-								<type>text</type>
-								<default>{powermail_all}</default>
-								<enableRichtext>1</enableRichtext>
-								<richtextConfiguration>default</richtextConfiguration>
-							</config>
-							<defaultExtras>richtext[]:rte_transform[mode=ts_css]</defaultExtras>
-						</TCEforms>
+						<exclude>1</exclude>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.sender.body</label>
+						<config>
+							<type>text</type>
+							<default>{powermail_all}</default>
+							<enableRichtext>1</enableRichtext>
+							<richtextConfiguration>default</richtextConfiguration>
+						</config>
+						<defaultExtras>richtext[]:rte_transform[mode=ts_css]</defaultExtras>
 					</settings.flexform.sender.body>
 				</el>
 			</ROOT>
 		</sender>
 		<thx>
 			<ROOT>
-				<TCEforms>
-					<sheetTitle>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.thx</sheetTitle>
-				</TCEforms>
+				<sheetTitle>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.thx</sheetTitle>
 				<type>array</type>
 				<el>
 					<settings.flexform.thx.body>
-						<TCEforms>
-							<exclude>1</exclude>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.thx.body</label>
-							<config>
-								<type>text</type>
-								<default>{powermail_all}</default>
-								<enableRichtext>1</enableRichtext>
-								<richtextConfiguration>default</richtextConfiguration>
-							</config>
-							<defaultExtras>richtext[]:rte_transform[mode=ts_css]</defaultExtras>
-						</TCEforms>
+						<exclude>1</exclude>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.thx.body</label>
+						<config>
+							<type>text</type>
+							<default>{powermail_all}</default>
+							<enableRichtext>1</enableRichtext>
+							<richtextConfiguration>default</richtextConfiguration>
+						</config>
+						<defaultExtras>richtext[]:rte_transform[mode=ts_css]</defaultExtras>
 					</settings.flexform.thx.body>
 					<settings.flexform.thx.redirect>
-						<TCEforms>
-							<exclude>1</exclude>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.thx.redirect</label>
-							<config>
-								<type>input</type>
-								<eval>trim</eval>
-								<renderType>inputLink</renderType>
-							</config>
-						</TCEforms>
+						<exclude>1</exclude>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.thx.redirect</label>
+						<config>
+							<type>input</type>
+							<eval>trim</eval>
+							<renderType>inputLink</renderType>
+						</config>
 					</settings.flexform.thx.redirect>
 				</el>
 			</ROOT>

--- a/Configuration/FlexForms/FlexformPi2.xml
+++ b/Configuration/FlexForms/FlexformPi2.xml
@@ -5,352 +5,305 @@
 	<sheets>
 		<main>
 			<ROOT>
-				<TCEforms>
-					<sheetTitle>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.main</sheetTitle>
-				</TCEforms>
+				<sheetTitle>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.main</sheetTitle>
 				<type>array</type>
 				<el>
 					<settings.flexform.main.form>
-						<TCEforms>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.main.form</label>
-							<config>
-								<type>group</type>
-								<internal_type>db</internal_type>
-								<allowed>tx_powermail_domain_model_form</allowed>
-								<size>1</size>
-								<minitems>1</minitems>
-								<maxitems>1</maxitems>
-								<required>1</required>
-								<wizards>
-									<_PADDING>0</_PADDING>
-									<suggest>
-										<type>suggest</type>
-									</suggest>
-								</wizards>
-							</config>
-							<onChange>reload</onChange>
-						</TCEforms>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.main.form</label>
+						<config>
+							<type>group</type>
+							<internal_type>db</internal_type>
+							<allowed>tx_powermail_domain_model_form</allowed>
+							<size>1</size>
+							<minitems>1</minitems>
+							<maxitems>1</maxitems>
+							<required>1</required>
+							<wizards>
+								<_PADDING>0</_PADDING>
+								<suggest>
+									<type>suggest</type>
+								</suggest>
+							</wizards>
+						</config>
+						<onChange>reload</onChange>
 					</settings.flexform.main.form>
 					<settings.flexform.main.pid>
-						<TCEforms>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.main.pid</label>
-							<config>
-								<type>group</type>
-								<internal_type>db</internal_type>
-								<allowed>pages</allowed>
-								<size>1</size>
-								<maxitems>1</maxitems>
-								<minitems>0</minitems>
-								<show_thumbs>1</show_thumbs>
-							</config>
-						</TCEforms>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.main.pid</label>
+						<config>
+							<type>group</type>
+							<internal_type>db</internal_type>
+							<allowed>pages</allowed>
+							<size>1</size>
+							<maxitems>1</maxitems>
+							<minitems>0</minitems>
+							<show_thumbs>1</show_thumbs>
+						</config>
 					</settings.flexform.main.pid>
 				</el>
 			</ROOT>
 		</main>
 		<list>
 			<ROOT>
-				<TCEforms>
-					<sheetTitle>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.list</sheetTitle>
-				</TCEforms>
+				<sheetTitle>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.list</sheetTitle>
 				<type>array</type>
 				<el>
 					<settings.flexform.list.fields>
-						<TCEforms>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.list.fields</label>
-							<config>
-								<type>select</type>
-								<renderType>selectMultipleSideBySide</renderType>
-								<items type="array">
-
-								</items>
-								<maxitems>100</maxitems>
-								<size>5</size>
-								<autoSizeMax>10</autoSizeMax>
-								<minitems>0</minitems>
-								<selectedListStyle>width:350px</selectedListStyle>
-								<itemListStyle>width:350px</itemListStyle>
-								<itemsProcFunc>In2code\Powermail\Tca\FieldSelectorUserFunc->getFieldSelection</itemsProcFunc>
-							</config>
-						</TCEforms>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.list.fields</label>
+						<config>
+							<type>select</type>
+							<renderType>selectMultipleSideBySide</renderType>
+							<items type="array">
+							</items>
+							<maxitems>100</maxitems>
+							<size>5</size>
+							<autoSizeMax>10</autoSizeMax>
+							<minitems>0</minitems>
+							<selectedListStyle>width:350px</selectedListStyle>
+							<itemListStyle>width:350px</itemListStyle>
+							<itemsProcFunc>In2code\Powermail\Tca\FieldSelectorUserFunc->getFieldSelection</itemsProcFunc>
+						</config>
 					</settings.flexform.list.fields>
 					<settings.flexform.list.export>
-						<TCEforms>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.list.export</label>
-							<config>
-								<type>select</type>
-								<renderType>selectMultipleSideBySide</renderType>
-								<items type="array">
-									<numIndex index="0" type="array">
-										<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.list.export.0</numIndex>
-										<numIndex index="1">xls</numIndex>
-									</numIndex>
-									<numIndex index="1" type="array">
-										<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.list.export.1</numIndex>
-										<numIndex index="1">csv</numIndex>
-									</numIndex>
-									<numIndex index="2" type="array">
-										<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.list.export.2</numIndex>
-										<numIndex index="1">rss</numIndex>
-									</numIndex>
-								</items>
-								<maxitems>10</maxitems>
-								<size>4</size>
-								<autoSizeMax>10</autoSizeMax>
-								<minitems>0</minitems>
-								<selectedListStyle>width:350px</selectedListStyle>
-								<itemListStyle>width:350px</itemListStyle>
-								<allowNonIdValues>1</allowNonIdValues>
-							</config>
-						</TCEforms>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.list.export</label>
+						<config>
+							<type>select</type>
+							<renderType>selectMultipleSideBySide</renderType>
+							<items type="array">
+								<numIndex index="0" type="array">
+									<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.list.export.0</numIndex>
+									<numIndex index="1">xls</numIndex>
+								</numIndex>
+								<numIndex index="1" type="array">
+									<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.list.export.1</numIndex>
+									<numIndex index="1">csv</numIndex>
+								</numIndex>
+								<numIndex index="2" type="array">
+									<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.list.export.2</numIndex>
+									<numIndex index="1">rss</numIndex>
+								</numIndex>
+							</items>
+							<maxitems>10</maxitems>
+							<size>4</size>
+							<autoSizeMax>10</autoSizeMax>
+							<minitems>0</minitems>
+							<selectedListStyle>width:350px</selectedListStyle>
+							<itemListStyle>width:350px</itemListStyle>
+							<allowNonIdValues>1</allowNonIdValues>
+						</config>
 					</settings.flexform.list.export>
 					<settings.flexform.list.delta>
-						<TCEforms>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.list.delta</label>
-							<config>
-								<type>input</type>
-								<size>10</size>
-							</config>
-						</TCEforms>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.list.delta</label>
+						<config>
+							<type>input</type>
+							<size>10</size>
+						</config>
 					</settings.flexform.list.delta>
 					<settings.flexform.list.limit>
-						<TCEforms>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.list.limit</label>
-							<config>
-								<type>input</type>
-								<size>10</size>
-							</config>
-						</TCEforms>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.list.limit</label>
+						<config>
+							<type>input</type>
+							<size>10</size>
+						</config>
 					</settings.flexform.list.limit>
 					<settings.flexform.list.pid>
-						<TCEforms>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.list.pid</label>
-							<config>
-								<type>group</type>
-								<internal_type>db</internal_type>
-								<allowed>pages</allowed>
-								<size>1</size>
-								<maxitems>1</maxitems>
-								<minitems>0</minitems>
-								<show_thumbs>1</show_thumbs>
-							</config>
-						</TCEforms>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.list.pid</label>
+						<config>
+							<type>group</type>
+							<internal_type>db</internal_type>
+							<allowed>pages</allowed>
+							<size>1</size>
+							<maxitems>1</maxitems>
+							<minitems>0</minitems>
+							<show_thumbs>1</show_thumbs>
+						</config>
 					</settings.flexform.list.pid>
 					<settings.flexform.list.showownonly>
-						<TCEforms>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.list.showownonly</label>
-							<config>
-								<type>check</type>
-								<items type="array">
-									<numIndex index="0" type="array">
-										<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.list.showownonly.0</numIndex>
-										<numIndex index="1">1</numIndex>
-									</numIndex>
-								</items>
-								<default>1</default>
-							</config>
-						</TCEforms>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.list.showownonly</label>
+						<config>
+							<type>check</type>
+							<items type="array">
+								<numIndex index="0" type="array">
+									<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.list.showownonly.0</numIndex>
+									<numIndex index="1">1</numIndex>
+								</numIndex>
+							</items>
+							<default>1</default>
+						</config>
 					</settings.flexform.list.showownonly>
 				</el>
 			</ROOT>
 		</list>
 		<single>
 			<ROOT>
-				<TCEforms>
-					<sheetTitle>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.single</sheetTitle>
-				</TCEforms>
+				<sheetTitle>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.single</sheetTitle>
 				<type>array</type>
 				<el>
 					<settings.flexform.single.fields>
-						<TCEforms>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.single.fields</label>
-							<config>
-								<type>select</type>
-								<renderType>selectMultipleSideBySide</renderType>
-								<items type="array">
-
-								</items>
-								<maxitems>100</maxitems>
-								<size>5</size>
-								<autoSizeMax>10</autoSizeMax>
-								<minitems>0</minitems>
-								<selectedListStyle>width:350px</selectedListStyle>
-								<itemListStyle>width:350px</itemListStyle>
-								<itemsProcFunc>In2code\Powermail\Tca\FieldSelectorUserFunc->getFieldSelection</itemsProcFunc>
-							</config>
-						</TCEforms>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.single.fields</label>
+						<config>
+							<type>select</type>
+							<renderType>selectMultipleSideBySide</renderType>
+							<items type="array">
+							</items>
+							<maxitems>100</maxitems>
+							<size>5</size>
+							<autoSizeMax>10</autoSizeMax>
+							<minitems>0</minitems>
+							<selectedListStyle>width:350px</selectedListStyle>
+							<itemListStyle>width:350px</itemListStyle>
+							<itemsProcFunc>In2code\Powermail\Tca\FieldSelectorUserFunc->getFieldSelection</itemsProcFunc>
+						</config>
 					</settings.flexform.single.fields>
 					<settings.flexform.single.activateLink>
-						<TCEforms>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.single.activateLink</label>
-							<config>
-								<type>check</type>
-								<items type="array">
-									<numIndex index="0" type="array">
-										<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.single.activateLink.0</numIndex>
-										<numIndex index="1">1</numIndex>
-									</numIndex>
-								</items>
-								<default>0</default>
-							</config>
-						</TCEforms>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.single.activateLink</label>
+						<config>
+							<type>check</type>
+							<items type="array">
+								<numIndex index="0" type="array">
+									<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.single.activateLink.0</numIndex>
+									<numIndex index="1">1</numIndex>
+								</numIndex>
+							</items>
+							<default>0</default>
+						</config>
 					</settings.flexform.single.activateLink>
 					<settings.flexform.single.pid>
-						<TCEforms>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.single.pid</label>
-							<config>
-								<type>group</type>
-								<internal_type>db</internal_type>
-								<allowed>pages</allowed>
-								<size>1</size>
-								<maxitems>1</maxitems>
-								<minitems>0</minitems>
-								<show_thumbs>1</show_thumbs>
-							</config>
-						</TCEforms>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.single.pid</label>
+						<config>
+							<type>group</type>
+							<internal_type>db</internal_type>
+							<allowed>pages</allowed>
+							<size>1</size>
+							<maxitems>1</maxitems>
+							<minitems>0</minitems>
+							<show_thumbs>1</show_thumbs>
+						</config>
 					</settings.flexform.single.pid>
 				</el>
 			</ROOT>
 		</single>
 		<search>
 			<ROOT>
-				<TCEforms>
-					<sheetTitle>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.search</sheetTitle>
-				</TCEforms>
+				<sheetTitle>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.search</sheetTitle>
 				<type>array</type>
 				<el>
 					<settings.flexform.search.fields>
-						<TCEforms>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.search.fields</label>
-							<config>
-								<type>select</type>
-								<renderType>selectMultipleSideBySide</renderType>
-								<items type="array">
-									<numIndex index="1" type="array">
-										<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.search.fields.all</numIndex>
-										<numIndex index="1">_all</numIndex>
-									</numIndex>
-								</items>
-								<maxitems>100</maxitems>
-								<size>3</size>
-								<autoSizeMax>10</autoSizeMax>
-								<minitems>0</minitems>
-								<selectedListStyle>width:350px</selectedListStyle>
-								<itemListStyle>width:350px</itemListStyle>
-								<itemsProcFunc>In2code\Powermail\Tca\FieldSelectorUserFunc->getFieldSelection</itemsProcFunc>
-								<allowNonIdValues>1</allowNonIdValues>
-							</config>
-						</TCEforms>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.search.fields</label>
+						<config>
+							<type>select</type>
+							<renderType>selectMultipleSideBySide</renderType>
+							<items type="array">
+								<numIndex index="1" type="array">
+									<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.search.fields.all</numIndex>
+									<numIndex index="1">_all</numIndex>
+								</numIndex>
+							</items>
+							<maxitems>100</maxitems>
+							<size>3</size>
+							<autoSizeMax>10</autoSizeMax>
+							<minitems>0</minitems>
+							<selectedListStyle>width:350px</selectedListStyle>
+							<itemListStyle>width:350px</itemListStyle>
+							<itemsProcFunc>In2code\Powermail\Tca\FieldSelectorUserFunc->getFieldSelection</itemsProcFunc>
+							<allowNonIdValues>1</allowNonIdValues>
+						</config>
 					</settings.flexform.search.fields>
 					<settings.flexform.search.abc>
-						<TCEforms>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.search.abc</label>
-							<config>
-								<type>select</type>
-								<renderType>selectSingle</renderType>
-								<items type="array">
-									<numIndex index="1" type="array">
-										<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.search.abc.off</numIndex>
-										<numIndex index="1"></numIndex>
-									</numIndex>
-								</items>
-								<maxitems>1</maxitems>
-								<size>1</size>
-								<itemsProcFunc>In2code\Powermail\Tca\FieldSelectorUserFunc->getFieldSelection</itemsProcFunc>
-							</config>
-						</TCEforms>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.search.abc</label>
+						<config>
+							<type>select</type>
+							<renderType>selectSingle</renderType>
+							<items type="array">
+								<numIndex index="1" type="array">
+									<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.search.abc.off</numIndex>
+									<numIndex index="1"></numIndex>
+								</numIndex>
+							</items>
+							<maxitems>1</maxitems>
+							<size>1</size>
+							<itemsProcFunc>In2code\Powermail\Tca\FieldSelectorUserFunc->getFieldSelection</itemsProcFunc>
+						</config>
 					</settings.flexform.search.abc>
 				</el>
 			</ROOT>
 		</search>
 		<edit>
 			<ROOT>
-				<TCEforms>
-					<sheetTitle>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.edit</sheetTitle>
-				</TCEforms>
+				<sheetTitle>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.edit</sheetTitle>
 				<type>array</type>
 				<el>
 					<settings.flexform.edit.fields>
-						<TCEforms>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.edit.fields</label>
-							<config>
-								<type>select</type>
-								<renderType>selectMultipleSideBySide</renderType>
-								<items type="array">
-
-								</items>
-								<maxitems>100</maxitems>
-								<size>5</size>
-								<autoSizeMax>10</autoSizeMax>
-								<minitems>0</minitems>
-								<selectedListStyle>width:350px</selectedListStyle>
-								<itemListStyle>width:350px</itemListStyle>
-								<itemsProcFunc>In2code\Powermail\Tca\FieldSelectorUserFunc->getFieldSelection</itemsProcFunc>
-							</config>
-						</TCEforms>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.edit.fields</label>
+						<config>
+							<type>select</type>
+							<renderType>selectMultipleSideBySide</renderType>
+							<items type="array">
+							</items>
+							<maxitems>100</maxitems>
+							<size>5</size>
+							<autoSizeMax>10</autoSizeMax>
+							<minitems>0</minitems>
+							<selectedListStyle>width:350px</selectedListStyle>
+							<itemListStyle>width:350px</itemListStyle>
+							<itemsProcFunc>In2code\Powermail\Tca\FieldSelectorUserFunc->getFieldSelection</itemsProcFunc>
+						</config>
 					</settings.flexform.edit.fields>
 					<settings.flexform.edit.feuser>
-						<TCEforms>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.edit.feuser</label>
-							<config>
-								<type>select</type>
-								<renderType>selectMultipleSideBySide</renderType>
-								<items type="array">
-									<numIndex index="1" type="array">
-										<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.edit.feuser.owner</numIndex>
-										<numIndex index="1">_owner</numIndex>
-									</numIndex>
-								</items>
-								<maxitems>100</maxitems>
-								<size>5</size>
-								<autoSizeMax>10</autoSizeMax>
-								<minitems>0</minitems>
-								<selectedListStyle>width:350px</selectedListStyle>
-								<itemListStyle>width:350px</itemListStyle>
-								<foreign_table>fe_users</foreign_table>
-								<foreign_table_where>AND fe_users.disable = 0 AND fe_users.deleted = 0 order by fe_users.username</foreign_table_where>
-								<allowNonIdValues>1</allowNonIdValues>
-                                <default>_owner</default>
-							</config>
-						</TCEforms>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.edit.feuser</label>
+						<config>
+							<type>select</type>
+							<renderType>selectMultipleSideBySide</renderType>
+							<items type="array">
+								<numIndex index="1" type="array">
+									<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.edit.feuser.owner</numIndex>
+									<numIndex index="1">_owner</numIndex>
+								</numIndex>
+							</items>
+							<maxitems>100</maxitems>
+							<size>5</size>
+							<autoSizeMax>10</autoSizeMax>
+							<minitems>0</minitems>
+							<selectedListStyle>width:350px</selectedListStyle>
+							<itemListStyle>width:350px</itemListStyle>
+							<foreign_table>fe_users</foreign_table>
+							<foreign_table_where>AND fe_users.disable = 0 AND fe_users.deleted = 0 order by fe_users.username</foreign_table_where>
+							<allowNonIdValues>1</allowNonIdValues>
+							<default>_owner</default>
+						</config>
 					</settings.flexform.edit.feuser>
 					<settings.flexform.edit.fegroup>
-						<TCEforms>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.edit.fegroup</label>
-							<config>
-								<type>select</type>
-								<renderType>selectMultipleSideBySide</renderType>
-								<items type="array">
-									<numIndex index="1" type="array">
-										<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.edit.feuser.owner</numIndex>
-										<numIndex index="1">_owner</numIndex>
-									</numIndex>
-								</items>
-								<maxitems>100</maxitems>
-								<size>5</size>
-								<autoSizeMax>10</autoSizeMax>
-								<minitems>0</minitems>
-								<selectedListStyle>width:350px</selectedListStyle>
-								<itemListStyle>width:350px</itemListStyle>
-								<foreign_table>fe_groups</foreign_table>
-								<foreign_table_where>AND fe_groups.hidden = 0 AND fe_groups.deleted = 0 order by fe_groups.title</foreign_table_where>
-								<allowNonIdValues>1</allowNonIdValues>
-							</config>
-						</TCEforms>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.edit.fegroup</label>
+						<config>
+							<type>select</type>
+							<renderType>selectMultipleSideBySide</renderType>
+							<items type="array">
+								<numIndex index="1" type="array">
+									<numIndex index="0">LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.edit.feuser.owner</numIndex>
+									<numIndex index="1">_owner</numIndex>
+								</numIndex>
+							</items>
+							<maxitems>100</maxitems>
+							<size>5</size>
+							<autoSizeMax>10</autoSizeMax>
+							<minitems>0</minitems>
+							<selectedListStyle>width:350px</selectedListStyle>
+							<itemListStyle>width:350px</itemListStyle>
+							<foreign_table>fe_groups</foreign_table>
+							<foreign_table_where>AND fe_groups.hidden = 0 AND fe_groups.deleted = 0 order by fe_groups.title</foreign_table_where>
+							<allowNonIdValues>1</allowNonIdValues>
+						</config>
 					</settings.flexform.edit.fegroup>
 					<settings.flexform.edit.pid>
-						<TCEforms>
-							<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.edit.pid</label>
-							<config>
-								<type>group</type>
-								<internal_type>db</internal_type>
-								<allowed>pages</allowed>
-								<size>1</size>
-								<maxitems>1</maxitems>
-								<minitems>0</minitems>
-								<show_thumbs>1</show_thumbs>
-							</config>
-						</TCEforms>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform_pi2.edit.pid</label>
+						<config>
+							<type>group</type>
+							<internal_type>db</internal_type>
+							<allowed>pages</allowed>
+							<size>1</size>
+							<maxitems>1</maxitems>
+							<minitems>0</minitems>
+							<show_thumbs>1</show_thumbs>
+						</config>
 					</settings.flexform.edit.pid>
 				</el>
 			</ROOT>


### PR DESCRIPTION
According to deprecation [#97126](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Deprecation-97126-TCEformsRemovedInFlexForm.html), the FlexForm tag TCEforms is no longer necessary and must be removed.