### PR TITLE
[BUGFIX] Fix exception when trying to XML export zero mail records

### DIFF
--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -142,7 +142,7 @@ class ModuleController extends AbstractController
                     'mails' => $this->mailRepository->findAllInPid($this->id, $this->settings, $this->piVars),
                     'fieldUids' => GeneralUtility::trimExplode(
                         ',',
-                        StringUtility::conditionalVariable($this->piVars['export']['fields'], ''),
+                        StringUtility::conditionalVariable($this->piVars['export']['fields'] ?? '', ''),
                         true
                     ),
                 ]


### PR DESCRIPTION
There's an exception when hitting the XLS export button on a folder without mail records. This fixes that.