### PR TITLE
[BUGFIX] Prevent exception "property mapping exception" at initialize…

### DIFF
--- a/Classes/Controller/FormController.php
+++ b/Classes/Controller/FormController.php
@@ -213,9 +213,6 @@ class FormController extends AbstractController
         if ($response !== null) {
             throw new PropagateResponseException($response);
         }
-
-        $this->reformatParamsForAction();
-        $this->debugVariables();
     }
 
     /**


### PR DESCRIPTION
Resolves [X1024](https://github.com/in2code-de/powermail/issues/1024)

Deleted property mapping execution (reformatParamsForAction) for initializeCheckCreateAction which caused an exception. 

it seems form submission works fine after that, not sure about if it doesn't broke [X969](https://github.com/in2code-de/powermail/issues/969) bugfix