### PR TITLE
[BUGFIX] avoid PHP Warning in StringValidator

### DIFF
--- a/Classes/Domain/Validator/StringValidator.php
+++ b/Classes/Domain/Validator/StringValidator.php
@@ -144,7 +144,7 @@ class StringValidator extends AbstractValidator
     protected function validateLength(string $value, string $configuration): bool
     {
         $values = GeneralUtility::trimExplode(',', $configuration, true);
-        if ((int)$values[0] <= 0) {
+        if (!isset($values[0]) || (int)$values[0] <= 0) {
             return true;
         }
         if (!isset($values[1])) {


### PR DESCRIPTION
this happens if using Length Validation without Configuration