### PR TITLE
[BUGFIX] Use correct table mapping for be_users and be_groups

### DIFF
--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -15,9 +15,9 @@ return [
         'tableName' => 'fe_groups',
     ],
     BackendUser::class => [
-        'tableName' => 'fe_users',
+        'tableName' => 'be_users',
     ],
     BackendUserGroup::class => [
-        'tableName' => 'fe_groups',
+        'tableName' => 'be_groups',
     ],
 ];


### PR DESCRIPTION
There was an error in the table mapping for be_users and be_groups, so setting up backend groups as receivers did not work.

See #1036 