### PR TITLE
[BUGFIX] Extended search with multiple custom fields support

### DIFF
--- a/Classes/Domain/Repository/MailRepository.php
+++ b/Classes/Domain/Repository/MailRepository.php
@@ -582,7 +582,7 @@ class MailRepository extends AbstractRepository
             // get intersection
             if (empty($customAnswerFieldRelations)) {
                 // no result -> do nothing
-                $customAnswersRelationIntersection = [];
+                $customAnswersRelationIntersection = null;
             } elseif (count($customAnswerFieldRelations) === 1) {
                 // only one custom field is part of the search
                 $customAnswersRelationIntersection = reset($customAnswerFieldRelations);
@@ -592,7 +592,7 @@ class MailRepository extends AbstractRepository
             }
 
             // Query with intersection
-            if (empty($customAnswersRelationIntersection))
+            if (empty($customAnswersRelationIntersection) && $customAnswersRelationIntersection !== null)
             {
                 // When intersection of custom answer field relations is empty, search is out of scope.
                 // Set a dummy uid - minus one (-1) will do this - to force out of scope result!


### PR DESCRIPTION
Extended Search in Backend Module with multiple values in Additional Fields (custom fields) cause empty search results.
Bugfixes this by query each field on its own and limiting the search by the intersection of the custom field relations