### PR TITLE
[TASK] Remove "defaultExtras"

### DIFF
--- a/Configuration/FlexForms/FlexformPi1.xml
+++ b/Configuration/FlexForms/FlexformPi1.xml
@@ -241,9 +241,7 @@
 								<type>text</type>
 								<default>{powermail_all}</default>
 								<enableRichtext>1</enableRichtext>
-								<richtextConfiguration>default</richtextConfiguration>
 							</config>
-							<defaultExtras>richtext[]:rte_transform[mode=ts_css]</defaultExtras>
 						</TCEforms>
 					</settings.flexform.receiver.body>
 				</el>
@@ -294,9 +292,7 @@
 								<type>text</type>
 								<default>{powermail_all}</default>
 								<enableRichtext>1</enableRichtext>
-								<richtextConfiguration>default</richtextConfiguration>
 							</config>
-							<defaultExtras>richtext[]:rte_transform[mode=ts_css]</defaultExtras>
 						</TCEforms>
 					</settings.flexform.sender.body>
 				</el>
@@ -317,9 +313,7 @@
 								<type>text</type>
 								<default>{powermail_all}</default>
 								<enableRichtext>1</enableRichtext>
-								<richtextConfiguration>default</richtextConfiguration>
 							</config>
-							<defaultExtras>richtext[]:rte_transform[mode=ts_css]</defaultExtras>
 						</TCEforms>
 					</settings.flexform.thx.body>
 					<settings.flexform.thx.redirect>


### PR DESCRIPTION
"defaultExtras" has already been removed in TYPO3 v8.6.

Furthermore, the "richtextConfiguration" has also been removed, as it is only initialized with "default", which TYPO3 automatically falls back to. However, not setting it allows it to be overwritten via PageTS

Fixes: #1065
Related: #262