### PR TITLE
[TASK] Remove git lfs and download development assets

### DIFF
--- a/.ddev/commands/host/initialize
+++ b/.ddev/commands/host/initialize
@@ -16,6 +16,9 @@ then
     exit
 fi
 
+# Create data directory
+mkdir -p .project/data
+
 for asset in "${ASSETS[@]}"
 do
     echo "Downloading $asset"

--- a/.ddev/commands/host/initialize
+++ b/.ddev/commands/host/initialize
@@ -4,14 +4,23 @@
 ## Usage: initialize
 ## Example: "ddev initialize"
 
-if ! command -v "git-lfs" &> /dev/null
+HOST=https://www.in2code.de
+ASSET_PATH=fileadmin/static/extensions/powermail
+ASSET_VERSION=v12
+ASSETS=(powermail-fileadmin.tar.gz powermail-db.gz)
+
+if ! command -v "curl" &> /dev/null
 then
-    echo "COMMAND "git lfs" could not be found"
-    echo "Please install git-lfs support, see: https://git-lfs.github.com/"
+    echo "COMMAND "curl" could not be found"
+    echo "Please install curl for downloading necessary assets in development environment"
     exit
 fi
 
-git lfs pull
+for asset in "${ASSETS[@]}"
+do
+    echo "Downloading $asset"
+    curl -s $HOST/$ASSET_PATH/$ASSET_VERSION/$asset -o .project/data/$asset
+done
 
 echo "Symlink configuration"
 cp .build/vendor/typo3/cms-install/Resources/Private/FolderStructureTemplateFiles/root-htaccess .build/public/.htaccess
@@ -22,13 +31,14 @@ ln -snf ../../../.project/typo3/settings.php .build/config/system/settings.php
 ln -snf ../../../.project/typo3/additional.php .build/config/system/additional.php
 
 echo "Importing database"
-ddev import-db --file=.project/data/db.sql.gz
+mv .project/data/powermail-db.gz .project/data/powermail-db.sql.gz
+ddev import-db --file=.project/data/powermail-db.sql.gz
 
 echo "Run 'composer install'"
 ddev composer install
 
 echo "Extracting fileadmin"
-tar xf .project/data/fileadmin.tar.gz -C .build/public/
+tar xf .project/data/powermail-fileadmin.tar.gz -C .build/public/
 
 echo "Copy .htaccess"
 cp .build/vendor/typo3/cms-install/Resources/Private/FolderStructureTemplateFiles/root-htaccess .build/public/.htaccess

--- a/.ddev/commands/host/initialize
+++ b/.ddev/commands/host/initialize
@@ -25,30 +25,32 @@ do
     curl -s $HOST/$ASSET_PATH/$ASSET_VERSION/$asset -o .project/data/$asset
 done
 
-echo "Symlink configuration"
+echo "Symlink site configuration"
 cp .build/vendor/typo3/cms-install/Resources/Private/FolderStructureTemplateFiles/root-htaccess .build/public/.htaccess
 mkdir -p .build/config/sites/main
 ln -snf ../../../../.project/typo3/config.yaml .build/config/sites/main/config.yaml
+
+echo "Symlink system configuration"
 mkdir -p .build/config/system
 ln -snf ../../../.project/typo3/settings.php .build/config/system/settings.php
 ln -snf ../../../.project/typo3/additional.php .build/config/system/additional.php
 
-echo "Importing database"
+echo "Import database"
 mv .project/data/powermail-db.gz .project/data/powermail-db.sql.gz
 ddev import-db --file=.project/data/powermail-db.sql.gz
 
 echo "Run 'composer install'"
 ddev composer install
 
-echo "Extracting fileadmin"
+echo "Extract fileadmin"
 tar xf .project/data/powermail-fileadmin.tar.gz -C .build/public/
 
 echo "Copy .htaccess"
 cp .build/vendor/typo3/cms-install/Resources/Private/FolderStructureTemplateFiles/root-htaccess .build/public/.htaccess
 
-echo "Update Languages (needed for behaviour tests)"
+echo "Update language packs (needed for behaviour tests)"
 ddev typo3 language:update
 
 ddev describe
 
-echo "Thanks for supporting 'EXT:powermail"
+echo "Thanks for supporting 'EXT:powermail'"

--- a/.gitattributes
+++ b/.gitattributes
@@ -21,5 +21,3 @@
 *.sql text eol=lf
 *.t3s text eol=lf
 *.txt text eol=lf
-*.tar.gz filter=lfs diff=lfs merge=lfs -text
-*.sql.gz filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,5 @@ config/
 /.phpunit.result.cache
 /phpunit.xml.dist.bak
 
-.project/data/screenshots
+.project/data
 /.phpunit.cache/

--- a/.project/data/db.sql.gz
+++ b/.project/data/db.sql.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5e08c34bf2b531a99037c6e9815411c1acbc63d75f5410f9502fd4ad7d25e263
-size 1609195

--- a/.project/data/fileadmin.tar.gz
+++ b/.project/data/fileadmin.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4396791fb67d4decb1c8960ea746f57a4d6ee85c0fb8c7830458efd58d279dfd
-size 926113


### PR DESCRIPTION
git lfs has issues when working with multiple organisations and lfs references are not available in all organisations. Providing the development assets via a direct download prevents theses issues.

Related: in2code-de/powermail#1047