### PR TITLE
[BUGFIX] Provide a fallback for null values

### DIFF
--- a/Classes/Update/PowermailPermissionUpdater.php
+++ b/Classes/Update/PowermailPermissionUpdater.php
@@ -113,7 +113,7 @@ class PowermailPermissionUpdater implements UpgradeWizardInterface
             'tt_content:list_type:powermail_pi1' => $pi1Replacement,
         ];
 
-        $newList = str_replace(array_keys($searchReplace), array_values($searchReplace), $row['explicit_allowdeny']);
+        $newList = str_replace(array_keys($searchReplace), array_values($searchReplace), $row['explicit_allowdeny'] ?? '');
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('be_groups');
         $queryBuilder->update('be_groups')
             ->set('explicit_allowdeny', $newList)


### PR DESCRIPTION
There might be situation, where the `explicit_allowdeny` column is null. (Probably very old installations, where the column had null as default. Providing an empty string as a fallback solves the issue.

Related: in2code-de/powermail#1062
Related: in2code-de/powermail#1019