### PR TITLE
add initializeCheckConfirmationAction to avoid "Required argument "ma…

### DIFF
--- a/Classes/Controller/FormController.php
+++ b/Classes/Controller/FormController.php
@@ -120,6 +120,21 @@ class FormController extends AbstractController
         return (new ForwardResponse('confirmation'))->withArguments($this->request->getArguments());
     }
 
+
+    public function initializeCheckConfirmationAction(): void
+    {
+        // ToDo -- v13: move exceptions to methods
+        $response = $this->forwardIfMailParamEmpty();
+        if ($response !== null) {
+            throw new PropagateResponseException($response);
+        }
+
+        $response = $this->forwardIfFormParamsDoNotMatch();
+        if ($response !== null) {
+            throw new PropagateResponseException($response);
+        }
+    }
+
     /**
      * @return void
      * @throws DeprecatedException


### PR DESCRIPTION
add initializeCheckConfirmationAction to avoid "Required argument "mail" is not set for In2code\Powermail\Controller\FormController->checkConfirmation"

This prevents the TYPO3 log from becoming cluttered.