### PR TITLE
[BUGFIX] Restore accidentally removed use-statement

### DIFF
--- a/Classes/Controller/OutputController.php
+++ b/Classes/Controller/OutputController.php
@@ -13,6 +13,7 @@ use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotCon
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
 use TYPO3\CMS\Core\Messaging\AbstractMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Annotation as ExtbaseAnnotation;
 use TYPO3\CMS\Extbase\Mvc\Exception\InvalidArgumentNameException;
 use TYPO3\CMS\Extbase\Mvc\Exception\NoSuchArgumentException;
 use TYPO3\CMS\Extbase\Mvc\Exception\StopActionException;


### PR DESCRIPTION
After updating Powermail to 8.5.0 in the website of one of our clients, I received a fatal error in the FE. Use statement `use TYPO3\CMS\Extbase\Annotation as ExtbaseAnnotation;` is removed in commit https://github.com/in2code-de/powermail/commit/2c8a1bf7669eb0661e8a93164f57e4b653ac3408, while it's still in use at line [161 of the OutputController](https://github.com/in2code-de/powermail/blob/typo3-v10/Classes/Controller/OutputController.php#L161).

In all other branches (like [master](https://github.com/in2code-de/powermail/blob/master/Classes/Controller/OutputController.php#L18)), this line is still present.