### PR TITLE
[BUGFIX] fix invalid phone regex

### DIFF
--- a/Classes/ViewHelpers/Validation/ValidationDataAttributeViewHelper.php
+++ b/Classes/ViewHelpers/Validation/ValidationDataAttributeViewHelper.php
@@ -195,13 +195,13 @@ class ValidationDataAttributeViewHelper extends AbstractValidationViewHelper
                  *
                  * html5 example:
                  *        <input type="text"
-                 *            pattern="/^(\+\d{1,4}|0+\d{1,5}|\(\d{1,5})[\d\s\/\(\)-]*\d+$/" />
+                 *            pattern="/^(\+\d{1,4}|0+\d{1,5}|\(\d{1,5})[\d\s\/\(\)\-]*\d+$/" />
                  * javascript example:
                  *        <input ... data-powermail-pattern=
-                 *            "/^(\+\d{1,4}|0+\d{1,5}|\(\d{1,5})[\d\s\/\(\)-]*\d+$/" />
+                 *            "/^(\+\d{1,4}|0+\d{1,5}|\(\d{1,5})[\d\s\/\(\)\-]*\d+$/" />
                  */
             case 3:
-                $pattern = '^(\+\d{1,4}|0+\d{1,5}|\(\d{1,5})[\d\s\/\(\)-]*\d+$';
+                $pattern = '^(\+\d{1,4}|0+\d{1,5}|\(\d{1,5})[\d\s\/\(\)\-]*\d+$';
                 if ($this->isNativeValidationEnabled()) {
                     $additionalAttributes['pattern'] = $pattern;
                 } else {


### PR DESCRIPTION
The dash at the end of the regex is interpreted as regex group in chrome and firefox so we have to escape it.

Error Message in Firefox:

`
<input pattern='/^(\+\d{1,4}|0+\d{1,5}|\(\d{1,5})[\d\s\/\(\)-]*\d+$/'> kann nicht überprüft werden, da '//^(\+\d{1,4}|0+\d{1,5}|\(\d{1,5})[\d\s\/\(\)-]*\d+$//v' keine gültige Regexp ist: invalid character in class in regular expression`