### PR TITLE
[BUGFIX] Prevent undefined array key warning in ForeignValidator::class

### DIFF
--- a/Classes/Domain/Validator/ForeignValidator.php
+++ b/Classes/Domain/Validator/ForeignValidator.php
@@ -40,7 +40,7 @@ class ForeignValidator extends AbstractValidator
             if (is_subclass_of($validatorConf['class'], $this->validatorInterface)) {
                 /** @var AbstractValidator $validator */
                 $validator = GeneralUtility::makeInstance($validatorConf['class']);
-                $validator->setConfiguration((array)$validatorConf['config']);
+                $validator->setConfiguration($validatorConf['config'] ?? []);
                 $validator->initialize();
                 /** @var Result $result */
                 $this->addErrors($validator->validate($mail));


### PR DESCRIPTION

Related: in2code-de/powermail#1105