### PR TITLE
[FEATURE] Use side-by-side select form forms

### DIFF
--- a/Configuration/FlexForms/FlexformPi1.xml
+++ b/Configuration/FlexForms/FlexformPi1.xml
@@ -12,10 +12,9 @@
 						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.main.form</label>
 						<config>
 							<type>select</type>
-							<renderType>selectSingle</renderType>
+							<renderType>selectMultipleSideBySide</renderType>
 							<items type="array">
 							</items>
-							<size>1</size>
 							<minitems>1</minitems>
 							<maxitems>1</maxitems>
 							<wizards>


### PR DESCRIPTION
Use TYPO3 renderType selectMultipleSideBySide to allow for filtering when selecting a form in the plugin.

This provides better usability when there are many forms.

Related: in2code-de/powermail#934