### PR TITLE
[FEATURE] Count "www"-prefixed words as link in spam-checker

### DIFF
--- a/Classes/Domain/Validator/SpamShield/LinkMethod.php
+++ b/Classes/Domain/Validator/SpamShield/LinkMethod.php
@@ -20,7 +20,7 @@ class LinkMethod extends AbstractMethod
             if (!is_string($answer->getValue())) {
                 continue;
             }
-            preg_match_all('@http://|https://|ftp://@', $answer->getValue(), $result);
+            preg_match_all('@http://|https://|ftp://|(^|\s)www\.\S@', $answer->getValue(), $result);
             if (isset($result[0])) {
                 $linkAmount += count($result[0]);
             }


### PR DESCRIPTION
This recognizes words like `www.example.org` as link and counts them into the spam-checker link-count.

This checks `www. …`-links for a space-character prefix to ensure that links like `https://www.example.org/` are not counted twice.

Regex: `'@http://|https://|ftp://|(^|\s)www\.\S@'`

Fixes: https://github.com/in2code-de/powermail/issues/1192