### PR TITLE
[BUGFIX] Exportcommand not working

### DIFF
--- a/Classes/Command/ExportCommand.php
+++ b/Classes/Command/ExportCommand.php
@@ -19,11 +19,16 @@ use TYPO3\CMS\Extbase\Persistence\Exception\InvalidQueryException;
  */
 class ExportCommand extends Command
 {
+
+    use FakeRequestTrait;
+    
     /**
      * @return void
      */
     public function configure()
     {
+        $this->fakeRequest();
+        
         $description =
             'This task can send a mail export with an attachment (XLS or CSV) to a receiver or a group of receivers';
         $this->setDescription($description);
@@ -104,7 +109,7 @@ class ExportCommand extends Command
         if ($period > 0) {
             $variables = [
                 'filter' => [
-                    'start' => strftime('%Y-%m-%d %H:%M:%S', (time() - $period)),
+                    'start' => date('Y-m-d H:i:s', (time() - $period)),
                     'stop' => 'now',
                 ],
             ];

--- a/Classes/Command/FakeRequestTrait.php
+++ b/Classes/Command/FakeRequestTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+namespace In2code\Powermail\Command;
+
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Http\ServerRequest;
+
+/**
+ * It is not possible to create an instance of an extbase repository in a symfony command anymore in TYPO3 12 or newer
+ * So we have to fake a request, to get this running again.
+ */
+trait FakeRequestTrait
+{
+    protected function fakeRequest()
+    {
+        if (!isset($GLOBALS['TYPO3_REQUEST'])) {
+            $request = (new ServerRequest())
+                ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE);
+            $GLOBALS['TYPO3_REQUEST'] = $request;
+        }
+    }
+}

--- a/Resources/Private/Templates/Module/ExportXls.html
+++ b/Resources/Private/Templates/Module/ExportXls.html
@@ -21,7 +21,7 @@
 										<vh:Getter.GetFieldLabelFromUid uid="{fieldUid}" />
 									</f:then>
 									<f:else>
-										<f:translate key="\In2code\Powermail\Domain\Model\Mail.{vh:string.underscoredToLowerCamelCase(val:fieldUid)}" />
+										<f:translate key="\In2code\Powermail\Domain\Model\Mail.{vh:string.underscoredToLowerCamelCase(val:fieldUid)}" extensionName="powermail" />
 									</f:else>
 								</f:if>
 							</th>
@@ -57,7 +57,7 @@
 											<f:if condition="{0:fieldUid} == {0:'crdate'}">
 												<f:then>
 													<f:format.date format="d.m.Y H:i:s"><vh:misc.variableInVariable obj="{mail}" prop="{fieldUid}" /></f:format.date>
-													<f:translate key="Clock" />
+													<f:translate key="Clock" extensionName="powermail" />
 												</f:then>
 												<f:else>
 													<f:if condition="{0 : fieldUid} == {0 : 'time'}">


### PR DESCRIPTION
In the CLI mode it's now necessary to implement a fakeRequest for this command.
Also the strftime is replaced and the exportxls template needs to have the extensionName param inside the f:translate tags.