### PR TITLE
[BUGFIX] Set correct export field uids

### DIFF
--- a/Resources/Private/Partials/Module/Export.html
+++ b/Resources/Private/Partials/Module/Export.html
@@ -148,6 +148,7 @@
 	<f:form.hidden
 			name="export[fields]"
 			value="{vh:string.implodeField(objects:'{vh:getter.getFieldsFromForm(form:firstForm,property:\'uid\',fieldType:\'exportable\')}')}"
-			id="export_fields" />
+			id="export_fields"
+			respectSubmittedDataValue="false" />
 </f:if>
 


### PR DESCRIPTION
As all filter requests are forwarded from the dispatch action to the list action, the request is evaluated as "invalid" and submitted form values are used by default. To ensure the current (new) field uids for an export are taken into account, the corresponding attribute "respectSubmittedDataValue" needs to be set.

Maybe related to: #1180

Resolves: #1089