### PR TITLE
[TASK] Use phpspreadsheet consistently

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -16,7 +16,6 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Mvc\Exception\NoSuchArgumentException;
@@ -110,7 +109,7 @@ abstract class AbstractController extends ActionController
         $this->uploadService = $uploadService;
         $this->eventDispatcher = $eventDispatcher;
 
-        $this->isPhpSpreadsheetInstalled = ExtensionManagementUtility::isLoaded('base_excel');
+        $this->isPhpSpreadsheetInstalled = class_exists(\PhpOffice\PhpSpreadsheet\IOFactory::class);
     }
 
     /**

--- a/Documentation/Index.md
+++ b/Documentation/Index.md
@@ -17,11 +17,13 @@ look at the final output in the frontend.
 Some basic points:
 
 - Main features of this mailform extension is to store the mails into
-  the database. Export it from the backend module (xls, csv) or list the
+  the database.
+
+- Export it from the backend module (xls, csv) or list the
   values in the frontend again (Pi2). XLS export in the backend is only
-  possible if the extension *jambagecom/base-excel*  is installed. In
-  classic installation, a phar file for phpspreadsheet must be manually
-  created (See docs of EXT:base_excel).
+  possible for classic installation, if a phar file for phpspreadsheet is manually
+  created (See docs of EXT:base_excel). In composer-based installation the neccessary
+  package is installed automatically.
 
 - Powermail send one or more mails to a static receiver or to dynamic receivers or
   to a whole Frontend-User Group.

--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,8 @@
 		"ext-curl": "*"
 	},
 	"suggest": {
-		"sjbr/static-info-tables": "*",
-		"jambagecom/base-excel": "^v1.29.0"
+		"sjbr/static-info-tables": "Provides country information for the country field",
+		"phpoffice/phpspreadsheet": "Enables xlsx export via the powermail module"
 	},
 	"replace": {
 		"typo3-ter/powermail": "self.version"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -19,6 +19,7 @@ $EM_CONF[$_EXTKEY] = [
         'conflicts' => [
         ],
         'suggests' => [
+            'base_excel' => '',
             'static_info_tables' => ''
         ],
     ],


### PR DESCRIPTION
- raise version numbers
- suggest the direct use of `phpoffice/phpspreadsheet` via composer
- suggest `EXT:base_excel` for legacy installations
- test for class existence of PhpSpreadSheet

Related: in2code-de/powermail#1214
Related: in2code-de/powermail#1208