### PR TITLE
aria-required not necessary when native required present

### DIFF
--- a/Classes/ViewHelpers/Validation/AbstractValidationViewHelper.php
+++ b/Classes/ViewHelpers/Validation/AbstractValidationViewHelper.php
@@ -75,7 +75,6 @@ abstract class AbstractValidationViewHelper extends AbstractViewHelper
                     $additionalAttributes['data-powermail-required'] = 'true';
                 }
             }
-            $additionalAttributes['aria-required'] = 'true';
 
             if ($this->isClientValidationEnabled()) {
                 $additionalAttributes['data-powermail-required-message'] =

--- a/Classes/ViewHelpers/Validation/ValidationDataAttributeViewHelper.php
+++ b/Classes/ViewHelpers/Validation/ValidationDataAttributeViewHelper.php
@@ -96,17 +96,14 @@ class ValidationDataAttributeViewHelper extends AbstractValidationViewHelper
             if ($field->isMandatory()) {
                 if ($this->isNativeValidationEnabled()) {
                     $additionalAttributes['required'] = 'required';
-                    $additionalAttributes['aria-required'] = 'true';
 
                     // remove required attribute if more checkboxes than 1
                     if ($field->getType() === 'check' && $iteration['total'] > 1) {
                         unset($additionalAttributes['required']);
-                        unset($additionalAttributes['aria-required']);
                     }
                 } else {
                     if ($this->isClientValidationEnabled()) {
                         $additionalAttributes['data-powermail-required'] = 'true';
-                        $additionalAttributes['aria-required'] = 'true';
                     }
                 }
                 if ($this->isClientValidationEnabled()) {
@@ -117,7 +114,6 @@ class ValidationDataAttributeViewHelper extends AbstractValidationViewHelper
                             LocalizationUtility::translate('validationerror_mandatory_multi');
                         if ($field->getType() === 'check') {
                             $additionalAttributes['data-powermail-required'] = 'true';
-                            $additionalAttributes['aria-required'] = 'true';
                         }
                     }
                 }

--- a/Tests/Unit/ViewHelpers/Validation/DatepickerDataAttributeViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Validation/DatepickerDataAttributeViewHelperTest.php
@@ -64,7 +64,6 @@ class DatepickerDataAttributeViewHelperTest extends UnitTestCase
                     'data-datepicker-format' => 'YYYY-MM-DD HH:mm',
                     'data-date-value' => 'anyvalue',
                     'required' => 'required',
-                    'aria-required' => 'true',
                     'data-powermail-required-message' => 'validationerror_mandatory',
                 ],
             ],


### PR DESCRIPTION
### Accessibility Note: Use of `required` vs `aria-required` (WCAG 2.1)

According to **WCAG 2.1**, it's important to use the correct attribute to indicate that a form field is required for assistive technologies. Here’s a breakdown of best practices:

---

#### ✅ `required` (HTML5 native attribute)
- Should be used on **native form elements** like `<input>`, `<select>`, and `<textarea>`.
- Recognized by **modern browsers** and **assistive technologies** (e.g., screen readers).
- Triggers **built-in form validation** and provides sufficient accessibility information.
- **No need to add `aria-required="true"`** if `required` is already present on native elements.

#### ✅ `aria-required="true"`
- Used **only** for **custom form controls** (e.g., a `<div>` with `role="textbox"`).
- Ensures that **assistive technologies** know the field is required when native HTML validation is not available.
- Does **not trigger** browser-native form validation.

---

### 🔧 Best Practice
- Use `required` for all **native HTML5 form elements**.
- Use `aria-required="true"` only when building **custom form components**.
- Avoid adding both `required` and `aria-required="true"` to the same native element – it’s redundant.

---

### 📘 WCAG 2.1 References
- **[3.3.1 Error Identification](https://www.w3.org/WAI/WCAG21/Understanding/error-identification.html)**
- **[4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)**
