### PR TITLE
Fix/memory leak on overrides

### DIFF
--- a/Classes/Domain/Model/Form.php
+++ b/Classes/Domain/Model/Form.php
@@ -32,6 +32,7 @@ class Form extends AbstractEntity
 
     /**
      * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\In2code\Powermail\Domain\Model\Page>
+     * @TYPO3\CMS\Extbase\Annotation\ORM\Lazy
      */
     protected $pages;
 

--- a/Classes/Domain/Model/Page.php
+++ b/Classes/Domain/Model/Page.php
@@ -30,6 +30,7 @@ class Page extends AbstractEntity
 
     /**
      * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\In2code\Powermail\Domain\Model\Field>
+     * @TYPO3\CMS\Extbase\Annotation\ORM\Lazy
      */
     protected $fields = null;
 


### PR DESCRIPTION
We noticed an issue when overriding the field and page model at the same time. It seems there is a infinite loop loading pages and fields then which leads to a memory overflow. The lazy loading fixes the issue as far as we could test.