### PR TITLE
12.x [BUGFIX] file uploads without file extension might cause exception

### DIFF
--- a/Classes/Domain/Service/UploadService.php
+++ b/Classes/Domain/Service/UploadService.php
@@ -131,7 +131,7 @@ class UploadService implements SingletonInterface
     {
         $filename = $file->getOriginalName();
         $fileInfo = pathinfo($filename);
-        $extension = strtolower($fileInfo['extension']);
+        $extension = strtolower($fileInfo['extension'] ?? '');
         if (!empty($extension) &&
             !empty($fileExtensions) &&
             GeneralUtility::inList($fileExtensions, $extension) &&


### PR DESCRIPTION
In case a file without extension is uploaded (e.g. a filename without a dot, like "pdf") an exception occurs, in all other cases a graceful false generates clear error messages. This simple fix should prevent the exception.

(The typical configuration for allowed file extensions in the form is ignored by some browsers, thus resulting in such files being selectable).