### PR TITLE
[BUGFIX] fix import paths in SiteSet TypoScript setup files

### DIFF
--- a/Configuration/Sets/Main/setup.typoscript
+++ b/Configuration/Sets/Main/setup.typoscript
@@ -1,1 +1,1 @@
-@import 'EXT:powermail/Configuration/Main/TypoScript/*.typoscript'
+@import 'EXT:powermail/Configuration/TypoScript/Main/Configuration/*.typoscript'

--- a/Configuration/Sets/Marketing/setup.typoscript
+++ b/Configuration/Sets/Marketing/setup.typoscript
@@ -1,1 +1,1 @@
-@import 'EXT:powermail/Configuration/Marketing/TypoScript/*.typoscript'
+@import 'EXT:powermail/Configuration/TypoScript/Marketing/setup.typoscript'

--- a/Configuration/Sets/Styling/setup.typoscript
+++ b/Configuration/Sets/Styling/setup.typoscript
@@ -1,1 +1,1 @@
-@import 'EXT:powermail/Configuration/Styling/TypoScript/*.typoscript'
+@import 'EXT:powermail/Configuration/TypoScript/Powermail_Styling/setup.typoscript'


### PR DESCRIPTION
The TypoScript import paths in the site sets _Main_, _Marketing_ and _Styling_ are incorrect.

This bugfix sets the correct import paths to the TypoScript files.

Additional note:  
The site set _DropInFrontend_ references the path EXT:powermail/Configuration/TypoScript/Powermail_Frontend but this path does not exist any more.  
The site set should probably be removed, since the related plugins and TypoScript have also been removed recently: https://github.com/in2code-de/powermail/commit/992d4b8d0cf63bd672a15ce6af481d04d1f592c1