### PR TITLE
[BUGFIX] fix site set settings definitions for view settings

### DIFF
--- a/Configuration/Sets/Main/settings.definitions.yaml
+++ b/Configuration/Sets/Main/settings.definitions.yaml
@@ -528,19 +528,19 @@ settings:
     type: bool
     default: true
 
-  plugin.tx_powermail.settings.view.templateRootPath:
+  plugin.tx_powermail.view.templateRootPath:
     label: Path to template root (FE)
     description: Path to template root (FE)
     category: powermail.view
     type: string
     default: 'EXT:powermail/Resources/Private/Templates/'
-  plugin.tx_powermail.settings.view.partialRootPath:
+  plugin.tx_powermail.view.partialRootPath:
     label: Path to template partials (FE)
     description: Path to template partials (FE)
     category: powermail.view
     type: string
     default: 'EXT:powermail/Resources/Private/Partials/'
-  plugin.tx_powermail.settings.view.layoutRootPath:
+  plugin.tx_powermail.view.layoutRootPath:
     label: Path to template layouts (FE)
     description: Path to template layouts (FE)
     category: powermail.view


### PR DESCRIPTION
The current view settings in the _Main_ site set settings definition file are incorrectly defined under `plugin.tx_powermail.settings.view.*`, which causes them to be ignored.  
This patch corrects the configuration keys to the proper format (by removing settings.) so they are recognized and used:

```
plugin.tx_powermail.settings.view.templateRootPath => plugin.tx_powermail.view.templateRootPath
plugin.tx_powermail.settings.view.partialRootPath => plugin.tx_powermail.view.partialRootPath
plugin.tx_powermail.settings.view.layoutRootPath => plugin.tx_powermail.view.layoutRootPath
```