### PR TITLE
[BUGFIX] strtolower argument 1 must be of type string, null given

### DIFF
--- a/Classes/Domain/Service/UploadService.php
+++ b/Classes/Domain/Service/UploadService.php
@@ -117,7 +117,7 @@ class UploadService implements SingletonInterface
     {
         $filename = $file->getOriginalName();
         $fileInfo = pathinfo($filename);
-        $extension = strtolower($fileInfo['extension']);
+        $extension = strtolower($fileInfo['extension'] ?? '');
         return $extension !== '' && $extension !== '0' &&
             ($fileExtensions !== '' && $fileExtensions !== '0') &&
             GeneralUtility::inList($fileExtensions, $extension) &&


### PR DESCRIPTION
In case a file without extension is uploaded (e.g. a filename without a dot, like "pdf") an exception occurs, in all other cases a graceful false generates clear error messages. This simple fix should prevent the exception.

This is for 13.x #1247 does it for 12.x 