### PR TITLE
Update phpoffice/phpspreadsheet to v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
 		"ext-gd": "*",
 		"ext-fileinfo": "*",
 		"ext-curl": "*",
-		"phpoffice/phpspreadsheet": "^4.0"
+		"phpoffice/phpspreadsheet": "^5.0"
 	},
 	"replace": {
 		"typo3-ter/powermail": "self.version"


### PR DESCRIPTION
Slightly "off-routine" dependency update. There's a security advisory on `phpoffice/phpspreadsheet` 4.x, but the way we do exports in Powermail is not affected by it (we also additionally sanitize cell values).

We checked and an update to 5.x works without any required adjustments from our end, so we'll just update the package to that.