### PR TITLE
[TASK] Hide label of honeypot field from screenreaders, too

### DIFF
--- a/Resources/Private/Partials/Misc/HoneyPod.html
+++ b/Resources/Private/Partials/Misc/HoneyPod.html
@@ -2,7 +2,7 @@
 
 <f:if condition="{vh:validation.isHonepodEnabled()}">
 	<div style="margin-left: -99999px; position: absolute;">
-		<label for="powermail_hp_{form.uid}">
+		<label for="powermail_hp_{form.uid}" aria-hidden="true">
 			<f:translate key="honeypodLabel" />
 		</label>
 		<f:form.textfield


### PR DESCRIPTION
Previously, this attribute was only applied to the input field, not to the label itself. Due to the styles of the container, the label is visually hidden but remains accessible to screen readers, while the corresponding input field is no longer accessible.