### PR TITLE
[BUGFIX] Re-add labels for powermail frontend

### DIFF
--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -772,6 +772,51 @@
 			<trans-unit id="BackendPluginInformationTitleLastMails" resname="BackendPluginInformationTitleLastMails">
 				<source>Last mails from this form</source>
 			</trans-unit>
+			<trans-unit id="BackendPluginInformationTitlePi2" resname="BackendPluginInformationTitlePi2">
+				<source>Show and manage mails in Frontend</source>
+			</trans-unit>
+			<trans-unit id="PowermailFrontendNoMails" resname="PowermailFrontendNoMails">
+				<source>No Mails found.</source>
+			</trans-unit>
+			<trans-unit id="PowermailFrontendFilterAll" resname="PowermailFrontendFilterAll">
+				<source>All</source>
+			</trans-unit>
+			<trans-unit id="PowermailFrontendFilterSubmit" resname="PowermailFrontendFilterSubmit">
+				<source>Filter Now</source>
+			</trans-unit>
+			<trans-unit id="PowermailFrontendNoMailsDetail" resname="PowermailFrontendNoMailsDetail">
+				<source>Please edit your filter settings.</source>
+			</trans-unit>
+			<trans-unit id="PowermailFrontendDetailView" resname="PowermailFrontendDetailView">
+				<source>Details</source>
+			</trans-unit>
+			<trans-unit id="PowermailFrontendEditView" resname="PowermailFrontendEditView">
+				<source>Edit</source>
+			</trans-unit>
+			<trans-unit id="PowermailFrontendDeleteView" resname="PowermailFrontendDeleteView">
+				<source>Delete</source>
+			</trans-unit>
+			<trans-unit id="PowermailFrontendEditSubmit" resname="PowermailFrontendEditSubmit">
+				<source>Save Changes</source>
+			</trans-unit>
+			<trans-unit id="PowermailFrontendEditConfirm" resname="PowermailFrontendEditConfirm">
+				<source>Changes successfully saved</source>
+			</trans-unit>
+			<trans-unit id="PowermailFrontendEditNoMail" resname="PowermailFrontendEditNoMail">
+				<source>Missing required Mail parameter</source>
+			</trans-unit>
+			<trans-unit id="PowermailFrontendEditFailed" resname="PowermailFrontendEditFailed">
+				<source>You are not allowed to make changes</source>
+			</trans-unit>
+			<trans-unit id="PowermailFrontendEditSuccessful" resname="PowermailFrontendEditSuccessful">
+				<source>Changes successfully saved</source>
+			</trans-unit>
+			<trans-unit id="PowermailFrontendDeleteFailed" resname="PowermailFrontendDeleteFailed">
+				<source>Record could not be removed</source>
+			</trans-unit>
+			<trans-unit id="PowermailFrontendDeleteSuccessful" resname="PowermailFrontendDeleteSuccessful">
+				<source>Record successfully removed</source>
+			</trans-unit>
 			<trans-unit id="ExtensionManagerConvertingScriptSuccess" resname="ExtensionManagerConvertingScriptSuccess">
 				<source>All tables successfully converted</source>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -522,6 +522,96 @@
 			<trans-unit id="flexform.thx.redirect" resname="flexform.thx.redirect">
 				<source>Redirect to any other Page after submit</source>
 			</trans-unit>
+			<trans-unit id="flexform_pi2.updateNote" resname="flexform_pi2.updateNote">
+				<source>ATTENTION: Please select a form in Settings before!</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.main" resname="flexform_pi2.main">
+				<source>Main Settings</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.main.form" resname="flexform_pi2.main.form">
+				<source>Choose a form</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.main.pid" resname="flexform_pi2.main.pid">
+				<source>Select a page with mails (optional)</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.list" resname="flexform_pi2.list">
+				<source>Listview</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.list.fields" resname="flexform_pi2.list.fields">
+				<source>Choose Fields to show (Empty: All Fields)</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.list.delta" resname="flexform_pi2.list.delta">
+				<source>Show entries of the last X Seconds (Empty: Function disabled)</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.list.limit" resname="flexform_pi2.list.limit">
+				<source>Show max. X entries (Empty: No Limit)</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.list.pid" resname="flexform_pi2.list.pid">
+				<source>Page with Plugin for list view (Empty: Same page)</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.list.showownonly" resname="flexform_pi2.list.showownonly">
+				<source>Own entries</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.list.showownonly.0" resname="flexform_pi2.list.showownonly.0">
+				<source>Show only entries from logged in Frontend-User</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.single" resname="flexform_pi2.single">
+				<source>Detailview</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.single.fields" resname="flexform_pi2.single.fields">
+				<source>Choose Fields to show (Empty: All Fields)</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.single.activateLink" resname="flexform_pi2.single.activateLink">
+				<source>Link to detail view</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.single.activateLink.0" resname="flexform_pi2.single.activateLink.0">
+				<source>active</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.single.pid" resname="flexform_pi2.single.pid">
+				<source>Page with Plugin for detail view (Empty: Same page)</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.search" resname="flexform_pi2.search">
+				<source>Searchsettings</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.search.fields" resname="flexform_pi2.search.fields">
+				<source>Add searchfield</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.search.fields.all" resname="flexform_pi2.search.fields.all">
+				<source>[Fulltext Search]</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.search.operator" resname="flexform_pi2.search.operator">
+				<source>search fields operator (AND / OR)</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.search.operator.0" resname="flexform_pi2.search.operator.0">
+				<source>OR (Find keyword in Field1 OR Field2)</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.search.operator.1" resname="flexform_pi2.search.operator.1">
+				<source>AND (Find keyword in Field1 AND Field2)</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.search.abc" resname="flexform_pi2.search.abc">
+				<source>Add ABC filter</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.search.abc.off" resname="flexform_pi2.search.abc.off">
+				<source>[Deactivated]</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.edit" resname="flexform_pi2.edit">
+				<source>Editview</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.edit.fields" resname="flexform_pi2.edit.fields">
+				<source>Choose Fields to edit (Empty: All fields)</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.edit.feuser" resname="flexform_pi2.edit.feuser">
+				<source>Choose one or more Frontend-Users with permission to change</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.edit.feuser.owner" resname="flexform_pi2.edit.feuser.owner">
+				<source>[Owner]</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.edit.fegroup" resname="flexform_pi2.edit.fegroup">
+				<source>Choose one or more Frontend-Groups with permission to change</source>
+			</trans-unit>
+			<trans-unit id="flexform_pi2.edit.pid" resname="flexform_pi2.edit.pid">
+				<source>Page with Plugin for edit view (Empty: Same page)</source>
+			</trans-unit>
 			<trans-unit id="pluginInfo.receiverEmail" resname="pluginInfo.receiverEmail">
 				<source>Receiver email address</source>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_mod.xlf
+++ b/Resources/Private/Language/locallang_mod.xlf
@@ -24,6 +24,24 @@
 			<trans-unit id="powermail_pi1.description">
 				<source>Powerful and easy mailform extension optimized for editors.</source>
 			</trans-unit>
+			<trans-unit id="powermail_pi2.title">
+				<source>Powermail Frontend (List, Detail)</source>
+			</trans-unit>
+			<trans-unit id="powermail_pi2.description">
+				<source>Displays powermail mails in the frontend</source>
+			</trans-unit>
+			<trans-unit id="powermail_pi3.title">
+				<source>Powermail Frontend (Edit, Update, Delete)</source>
+			</trans-unit>
+			<trans-unit id="powermail_pi3.description">
+				<source>Displays an edit form and allows to delete sent emails</source>
+			</trans-unit>
+			<trans-unit id="powermail_pi4.title">
+				<source>Powermail Frontend (All functions)</source>
+			</trans-unit>
+			<trans-unit id="powermail_pi4.description">
+				<source>A plugin with all actions</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>


### PR DESCRIPTION
Since crowdin translations are solely based on the master branch, these translations and labels are also used for TYPO3 v12 compatible releases. In order to provide translations for old versions, we need to re-add that stuff.

Related: in2code-de/powermail#1272