### PR TITLE
[TASK] Align length of receiver mail database field and flexform

### DIFF
--- a/Configuration/FlexForms/FlexformPi1.xml
+++ b/Configuration/FlexForms/FlexformPi1.xml
@@ -127,6 +127,7 @@
 							<type>text</type>
 							<cols>32</cols>
 							<rows>2</rows>
+                            <max>1000</max>
 						</config>
 					</settings.flexform.receiver.email>
 					<settings.flexform.receiver.fe_group>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -159,7 +159,7 @@ CREATE TABLE tx_powermail_domain_model_mail (
 	sender_name varchar(255) DEFAULT '' NOT NULL,
 	sender_mail varchar(255) DEFAULT '' NOT NULL,
 	subject varchar(255) DEFAULT '' NOT NULL,
-	receiver_mail varchar(255) DEFAULT '' NOT NULL,
+	receiver_mail varchar(1024) DEFAULT '' NOT NULL,
 	body text NOT NULL,
 	feuser int(11) DEFAULT '0' NOT NULL,
 	sender_ip tinytext NOT NULL,


### PR DESCRIPTION
The database field was 255 characters long, the flexform field had "no" limitation. The length of both fields was adjusted.

Related: https://github.com/in2code-de/powermail/issues/1230