### PR TITLE
[TASK] Require __hp field in arguments when honeypot spamcheck enabled

### DIFF
--- a/Classes/Domain/Validator/SpamShield/HoneyPodMethod.php
+++ b/Classes/Domain/Validator/SpamShield/HoneyPodMethod.php
@@ -15,6 +15,6 @@ class HoneyPodMethod extends AbstractMethod
      */
     public function spamCheck(): bool
     {
-        return !empty($this->arguments['field']['__hp']);
+        return !isset($this->arguments['field']['__hp']) || !empty($this->arguments['field']['__hp']);
     }
 }


### PR DESCRIPTION
When the honeypot spamcheck is enabled, the `__hp` field is automatically rendered as invisible field in the frontend. The spamcheck currently only checks, if the content of the field is not empty. The field can however be completely omitted in the POST request, so spambots may more easily find out, that the `__hp` field should not be sent in the POST request at all.

This change hardens the honeypot spamcheck by requiring the `__hp` field to be present in the POST request. If the field is omitted, the spamcheck will fail.