### PR TITLE
[BUGFIX] Provide fields that are changed via SendMailServicePrepareAn…

### DIFF
--- a/Classes/Domain/Service/Mail/SendMailService.php
+++ b/Classes/Domain/Service/Mail/SendMailService.php
@@ -113,6 +113,8 @@ class SendMailService
         $event = $this->eventDispatcher->dispatch(
             new SendMailServicePrepareAndSendEvent($message, $email, $this)
         );
+        $email = $event->getEmail();
+        $message = $event->getMailMessage();
         if ($event->isAllowedToSend() === false) {
             if ($GLOBALS['TYPO3_CONF_VARS']['BE']['debug']) {
                 $logger = ObjectUtility::getLogger(self::class);


### PR DESCRIPTION
…dSendEvent

It is possible to change the email and message in
SendMailServicePrepareAndSendEvent. The results were not passed back to the SendMailService. This works now.

Related: in2code-de/powermail#1236