### PR TITLE
[BUGFIX] Prevent infinite loop when trustedProperties validation fails

### DIFF
--- a/Classes/Controller/FormController.php
+++ b/Classes/Controller/FormController.php
@@ -38,6 +38,7 @@ use In2code\Powermail\Utility\LocalizationUtility;
 use In2code\Powermail\Utility\ObjectUtility;
 use In2code\Powermail\Utility\SessionUtility;
 use In2code\Powermail\Utility\TemplateUtility;
+use TYPO3\CMS\Core\Error\Http\BadRequestException;
 use function in_array;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ResponseInterface;


### PR DESCRIPTION
If the __trustedProperties hidden property of a form is manipulated or submit as empty, the HMAC validation fails, throwing an exception.

The normal exception handling then tries to forward the request to the formAction, which itself also validates the HMAC. This leads to an infinite loop which is only resolved after 100 iterations by throwing an InfiniteLoopException.

This process takes time, therefore Powermail is vulnerable to DoS attacks.

The change checks for a BadRequestException from the HMAC validation. In such a case, a redirect to the (then empty) formAction is performed and the error is logged.

Resolves: #1293