### PR TITLE
[BUGFIX] Provide fields that are changed via SendMailServicePrepareAn…

### DIFF
--- a/Classes/Domain/Service/Mail/SendMailService.php
+++ b/Classes/Domain/Service/Mail/SendMailService.php
@@ -137,6 +137,8 @@ class SendMailService
         $event = $this->eventDispatcher->dispatch(
             GeneralUtility::makeInstance(SendMailServicePrepareAndSendEvent::class, $message, $email, $this)
         );
+        $email = $event->getEmail();
+        $message = $event->getMailMessage();
         if ($event->isAllowedToSend() === false) {
             if ($this->settings['debug']['mail']) {
                 $logger = ObjectUtility::getLogger(__CLASS__);


### PR DESCRIPTION
…dSendEvent

It is possible to change the email and message in
SendMailServicePrepareAndSendEvent. The results were not passed back to the SendMailService. This works now.

Related: in2code-de/powermail#1236
(cherry picked from commit e9b94190f9d74b716267061292fae728158f296a)