### PR TITLE
[TASK] Standardise the spelling of ViewHelpers to lowerCamelCase

### DIFF
--- a/Resources/Private/Partials/Form/Page.html
+++ b/Resources/Private/Partials/Form/Page.html
@@ -6,7 +6,7 @@
 
     <f:for each="{page.fields}" as="field" iteration="iteration">
         <vh:misc.createRowTags columns="{settings.styles.numberOfColumns}" class="{settings.styles.framework.rowClasses}" iteration="{iteration}">
-            <f:render partial="Form/Field/{vh:String.Upper(string:field.type)}" arguments="{field:field}"/>
+            <f:render partial="Form/Field/{vh:string.upper(string:field.type)}" arguments="{field:field}"/>
         </vh:misc.createRowTags>
     </f:for>
 

--- a/Resources/Private/Templates/Form/PowermailAll.html
+++ b/Resources/Private/Templates/Form/PowermailAll.html
@@ -37,10 +37,10 @@ Section for Mails
 <f:section name="mail">
 	<table class="powermail_all">
 		<f:for each="{mail.answers}" as="answer">
-			<f:if condition="{vh:Condition.isNotExcludedFromPowermailAll(answer:answer, type:type, settings:settings)}">
+			<f:if condition="{vh:condition.isNotExcludedFromPowermailAll(answer:answer, type:type, settings:settings)}">
 				<f:if condition="{settings.misc.showOnlyFilledValues}">
 					<f:then>
-						<f:if condition="{vh:Condition.IsNotEmpty(val:'{answer.value}')}">
+						<f:if condition="{vh:condition.isNotEmpty(val:'{answer.value}')}">
 							<f:render partial="PowermailAll/Mail" arguments="{_all}" />
 						</f:if>
 					</f:then>

--- a/Resources/Private/Templates/Module/ExportXls.html
+++ b/Resources/Private/Templates/Module/ExportXls.html
@@ -18,7 +18,7 @@
 							<th>
 								<f:if condition="{vh:condition.isNumber(val:fieldUid)}">
 									<f:then>
-										<vh:Getter.GetFieldLabelFromUid uid="{fieldUid}" />
+										<vh:getter.getFieldLabelFromUid uid="{fieldUid}" />
 									</f:then>
 									<f:else>
 										<f:translate key="\In2code\Powermail\Domain\Model\Mail.{vh:string.underscoredToLowerCamelCase(val:fieldUid)}" extensionName="powermail" />
@@ -65,7 +65,7 @@
 															<f:format.date format="%M:%S"><vh:misc.variableInVariable obj="{mail}" prop="{fieldUid}" /></f:format.date>
 														</f:then>
 														<f:else>
-															<f:format.date format="H:i:s"><vh:Misc.VariableInVariable obj="{mail}" prop="{fieldUid}" /></f:format.date>
+															<f:format.date format="H:i:s"><vh:misc.variableInVariable obj="{mail}" prop="{fieldUid}" /></f:format.date>
 														</f:else>
 													</f:if>
 												</f:else>


### PR DESCRIPTION
It is common practice to write ViewHelpers in Fluid templates in lowerCamelCase.
Adherence to this standard also supports code completion in IDEs, for example.