### PR TITLE
[TASK] Remove deprecated TCA `internal_type`

### DIFF
--- a/Configuration/FlexForms/FlexformPi1.xml
+++ b/Configuration/FlexForms/FlexformPi1.xml
@@ -60,7 +60,6 @@
 						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.main.pid</label>
 						<config>
 							<type>group</type>
-							<internal_type>db</internal_type>
 							<allowed>pages</allowed>
 							<size>1</size>
 							<maxitems>1</maxitems>

--- a/Configuration/TCA/tx_powermail_domain_model_form.php
+++ b/Configuration/TCA/tx_powermail_domain_model_form.php
@@ -193,7 +193,6 @@ if (ConfigurationUtility::isReplaceIrreWithElementBrowserActive()) {
         'label' => 'LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:' . Form::TABLE_NAME . '.pages',
         'config' => [
             'type' => 'group',
-            'internal_type' => 'db',
             'allowed' => Page::TABLE_NAME,
             'foreign_table' => Page::TABLE_NAME,
             'minitems' => 1,


### PR DESCRIPTION
The option `'internal_type' => 'db'` in TCA for `tx_powermail_domain_model_form.pages` has been removed. It is no longer needed since TYPO3 v11.5 and deprecated with v12.0.

See [Deprecation #96983](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Deprecation-96983-TCAInternal_type.html)