### PR TITLE
[TASK] FlexForm deprecation fixes and cleanup

### DIFF
--- a/Configuration/FlexForms/FlexformPi1.xml
+++ b/Configuration/FlexForms/FlexformPi1.xml
@@ -126,7 +126,7 @@
 							<type>text</type>
 							<cols>32</cols>
 							<rows>2</rows>
-                            <max>1000</max>
+							<max>1000</max>
 						</config>
 					</settings.flexform.receiver.email>
 					<settings.flexform.receiver.fe_group>
@@ -201,24 +201,24 @@
 						</config>
 					</settings.flexform.receiver.subject>
 					<settings.flexform.receiver.body>
-                        <exclude>1</exclude>
-                        <label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.body</label>
-                        <config>
-                            <type>text</type>
-                            <default>{powermail_all}</default>
-                            <enableRichtext>1</enableRichtext>
-                        </config>
+						<exclude>1</exclude>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.body</label>
+						<config>
+							<type>text</type>
+							<default>{powermail_all}</default>
+							<enableRichtext>1</enableRichtext>
+						</config>
 					</settings.flexform.receiver.body>
-                    <settings.flexform.receiver.attachment>
-                        <displayCond>USER:In2code\Powermail\UserFunc\TestForFeature->isFeatureEnabled:powermailEditorsAreAllowedToSendAttachments</displayCond>
-                        <exclude>1</exclude>
-                        <label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.attachment</label>
-                        <config>
-                            <type>check</type>
-                            <default>0</default>
-                        </config>
-                    </settings.flexform.receiver.attachment>
-                </el>
+					<settings.flexform.receiver.attachment>
+						<displayCond>USER:In2code\Powermail\UserFunc\TestForFeature->isFeatureEnabled:powermailEditorsAreAllowedToSendAttachments</displayCond>
+						<exclude>1</exclude>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.receiver.attachment</label>
+						<config>
+							<type>check</type>
+							<default>0</default>
+						</config>
+					</settings.flexform.receiver.attachment>
+				</el>
 			</ROOT>
 		</receiver>
 		<sender>
@@ -259,16 +259,16 @@
 							<enableRichtext>1</enableRichtext>
 						</config>
 					</settings.flexform.sender.body>
-                    <settings.flexform.sender.attachment>
-                        <displayCond>USER:In2code\Powermail\UserFunc\TestForFeature->isFeatureEnabled:powermailEditorsAreAllowedToSendAttachments</displayCond>
-                        <exclude>1</exclude>
-                        <label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.sender.attachment</label>
-                        <config>
-                            <type>check</type>
-                            <default>0</default>
-                        </config>
-                    </settings.flexform.sender.attachment>
-                </el>
+					<settings.flexform.sender.attachment>
+						<displayCond>USER:In2code\Powermail\UserFunc\TestForFeature->isFeatureEnabled:powermailEditorsAreAllowedToSendAttachments</displayCond>
+						<exclude>1</exclude>
+						<label>LLL:EXT:powermail/Resources/Private/Language/locallang_db.xlf:flexform.sender.attachment</label>
+						<config>
+							<type>check</type>
+							<default>0</default>
+						</config>
+					</settings.flexform.sender.attachment>
+				</el>
 			</ROOT>
 		</sender>
 		<thx>


### PR DESCRIPTION
FlexForm definitions were updated to prevent on-the-fly migrations performed by FlexFormTools. TYPO3 v12+ introduced new TCA requirements which deprecate certain configurations.

- Field `settings.flexform.receiver.type` was corrected by fixing inconsistent items ordering and removing an invalid attribute ([Deprecation: #99739](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.3/Deprecation-99739-IndexedArrayKeysForTCAItems.html)).
- Field `settings.flexform.thx.redirect` was migrated from deprecated `type="input"` with `renderType="inputLink"` to the modern `type="link"` configuration ([Feature: #97159](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-97159-NewTCATypeLink.html#feature-97159)).
- Indentation in FlexForm XML was normalized by replacing 4 spaces with tabs for consistent formatting.