### PR TITLE
[BUGFIX] Fix prefilling form with current logged in user

### DIFF
--- a/Classes/Utility/FrontendUtility.php
+++ b/Classes/Utility/FrontendUtility.php
@@ -158,12 +158,7 @@ class FrontendUtility
      */
     public static function isLoggedInFrontendUser(): bool
     {
-        $request = self::getRequest();
-        if ($request !== null) {
-            return $request->getAttribute('frontend.user')->isActiveLogin($request);
-        }
-
-        return false;
+        return (int)self::getPropertyFromLoggedInFrontendUser() > 0;
     }
 
     /**


### PR DESCRIPTION
To prefill a form with the current user it is needed to check if the user is logged in. This condition was broken.

Resolves #1323