### PR TITLE
[BUGFIX] Render label & description for the 'auto_marker' field

### DIFF
--- a/Classes/Tca/Marker.php
+++ b/Classes/Tca/Marker.php
@@ -13,6 +13,17 @@ use TYPO3\CMS\Backend\Form\Element\AbstractFormElement;
  */
 class Marker extends AbstractFormElement
 {
+    /**
+     * Default field information enabled for this element.
+     *
+     * @var array
+     */
+    protected $defaultFieldInformation = [
+        'tcaDescription' => [
+            'renderType' => 'tcaDescription',
+        ],
+    ];
+
     public function render(): array
     {
         $result = $this->initializeResultArray();
@@ -25,7 +36,9 @@ class Marker extends AbstractFormElement
      */
     protected function getHtml(): string
     {
-        $content = '';
+        // Render the description of the field
+        $fieldInformationResult = $this->renderFieldInformation();
+        $content = $fieldInformationResult['html'];
 
         // if entry in db
         $marker = empty($this->data['databaseRow']['marker']) ? 'marker' : $this->data['databaseRow']['marker'];
@@ -44,6 +57,7 @@ class Marker extends AbstractFormElement
                 $this->data['databaseRow']['uid'] . '][marker]" value="' . strtolower((string)$marker) . '" />';
         }
 
-        return $content;
+        // Add the label & legend
+        return $this->wrapWithFieldsetAndLegend($content);
     }
 }


### PR DESCRIPTION
The `label` & `description` TCA properties are not rendered for the `auto_marker` field of the `tx_powermail_domain_model_field` table:

- the `label` was rendered in previous TYPO3 versions but it is not rendered anymore in TYPO3 13 due to [this change](https://docs.typo3.org/permalink/t3tca:columns-user-examples) : 

> The label of a custom field does not get rendered automatically anymore but must be rendered with $this->renderLabel($fieldId) or $this->wrapWithFieldsetAndLegend().

- the 'description' was never rendered for this field
