### PR TITLE
Move RedirectFinisher to always execute last using "finally" key

### DIFF
--- a/Classes/Finisher/FinisherRunner.php
+++ b/Classes/Finisher/FinisherRunner.php
@@ -112,6 +112,19 @@ class FinisherRunner
     protected function getFinisherClasses(array $settings): array
     {
         $finishers = (array)$settings['finishers'];
+
+        if (!empty($finishers['finally'])) {
+            $finalFinisher = $finishers['finally'];
+            unset($finishers['finally']);
+
+            // backwards compatibility: check if someone "moved" the RedirectFinisher in typoscript
+            $finalClassName = $finalFinisher['class'] ?? null;
+            if ($finalClassName && !in_array($finalClassName, array_column($finishers, 'class'), true)) {
+                // add the finally finisher at the next numeric key
+                $finishers[max(array_keys($finishers)) + 1] = $finalFinisher;
+            }
+        }
+
         ksort($finishers);
         return $finishers;
     }

--- a/Configuration/TypoScript/Main/Configuration/30_Finisher.typoscript
+++ b/Configuration/TypoScript/Main/Configuration/30_Finisher.typoscript
@@ -6,7 +6,7 @@ plugin.tx_powermail.settings.setup {
     # Powermail finishers
     10.class = In2code\Powermail\Finisher\SaveToAnyTableFinisher
     20.class = In2code\Powermail\Finisher\SendParametersFinisher
-    100.class = In2code\Powermail\Finisher\RedirectFinisher
+    finally.class = In2code\Powermail\Finisher\RedirectFinisher
 
     # EXAMPLE: Add your own finishers classes (e.g. if you want to do something with form values by your own: Save into tables, call an API, make your own redirect etc...)
     # 1 {

--- a/Documentation/ForDevelopers/AddFinisherClasses.md
+++ b/Documentation/ForDevelopers/AddFinisherClasses.md
@@ -170,3 +170,20 @@ class DoSomethingFinisher extends AbstractFinisher
 * Every finisher method could have its own initialize method, which will be called before. Like `initializeMyFinisher()` before `myFinisher()`.
 * Classes in extensions (if namespace and filename fits) will be automatically included from TYPO3 autoloader. If you place a single file in fileadmin, use "require" in TypoScript.
 * Per default 10, 20 and 100 is already in use from powermail itself (SaveToAnyTableFinisher, SendParametersFinisher, RedirectFinisher).
+* The `RedirectFinisher` is automatically treated as a "finally" finisher and will always execute **last**.
+  This ensures that all other finishers, including custom finishers from other extensions, are executed before the redirect.
+* Developers can continue to define finishers with numeric keys. These finishers will run in order, but the RedirectFinisher will always run at the end.
+* The full configuration of the RedirectFinisher, including `config` and `require` options, is preserved.
+
+
+## Execution Order and the RedirectFinisher
+
+Powermail finishers are executed in the order of their numeric keys.
+Previously, a `RedirectFinisher` with a lower numeric key could prevent finishers with higher keys from executing, because it throws a `PropagateResponseException`.
+
+To solve this, the `RedirectFinisher` is now always executed **last** by default, regardless of its numeric key.
+This guarantees that:
+
+* Custom finishers from your extensions or other integrations will run reliably.
+* Redirects happen only after all other finishers have finished their work.
+* You do not need to add a special `finally` key yourself — it is handled automatically.


### PR DESCRIPTION
Problem:
- Finishers are sorted by numeric keys, which can cause custom finishers to be skipped.
- RedirectFinisher throws a PropagateResponseException, halting execution of any finishers with higher keys.

Solution:
- Introduce a "finally" key in the finisher configuration.
- If a finisher is defined under "finally", it is moved to the highest numeric key.
- Preserves the full finisher structure and avoids duplicates if the class is already present.
- Ensures RedirectFinisher (or any finally finisher) always runs last, without losing custom finishers.

Example:
plugin.tx_powermail.settings.setup.finishers {
    10.class = In2code\Powermail\Finisher\SaveToAnyTableFinisher
    20.class = In2code\Powermail\Finisher\SendParametersFinisher
    finally.class = In2code\Powermail\Finisher\RedirectFinisher
    1000.class = Vendor\Ext\Finisher\CustomFinisher
}

This guarantees predictable execution order and maintains backward compatibility with manual configurations.

resolves #1346