### PR TITLE
[BUGFIX] Backend form selector and module must not apply frontend enable column restrictions

### DIFF
--- a/Classes/Domain/Repository/FormRepository.php
+++ b/Classes/Domain/Repository/FormRepository.php
@@ -95,7 +95,10 @@ class FormRepository extends AbstractRepository
     public function findAll()
     {
         $query = $this->createQuery();
-        $query->getQuerySettings()->setRespectStoragePage(false);
+        $query->getQuerySettings()
+            ->setRespectStoragePage(false)
+            ->setIgnoreEnableFields(true)
+            ->setEnableFieldsToBeIgnored(['disabled', 'starttime', 'endtime']);
         return $query->execute();
     }
 
@@ -108,7 +111,10 @@ class FormRepository extends AbstractRepository
     public function findAllInPidAndRootline(int $pid): QueryResultInterface
     {
         $query = $this->createQuery();
-        $query->getQuerySettings()->setRespectStoragePage(false);
+        $query->getQuerySettings()
+            ->setRespectStoragePage(false)
+            ->setIgnoreEnableFields(true)
+            ->setEnableFieldsToBeIgnored(['disabled', 'starttime', 'endtime']);
 
         if ($pid > 0) {
             $queryGenerator = GeneralUtility::makeInstance(QueryGenerator::class);

--- a/Classes/Tca/FormSelectorUserFunc.php
+++ b/Classes/Tca/FormSelectorUserFunc.php
@@ -12,6 +12,8 @@ use In2code\Powermail\Exception\DeprecatedException;
 use In2code\Powermail\Utility\BackendUtility;
 use In2code\Powermail\Utility\DatabaseUtility;
 use TYPO3\CMS\Backend\Utility\BackendUtility as BackendUtilityCore;
+use TYPO3\CMS\Core\Database\Query\Restriction\EndTimeRestriction;
+use TYPO3\CMS\Core\Database\Query\Restriction\StartTimeRestriction;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -111,6 +113,11 @@ class FormSelectorUserFunc
     protected function getAllForms(int $startPid, int $language): array
     {
         $queryBuilder = DatabaseUtility::getQueryBuilderForTable(Form::TABLE_NAME);
+        // Remove frontend-only time restrictions so forms with starttime/endtime
+        // remain selectable in the backend plugin configuration regardless of their
+        // frontend visibility window.
+        $queryBuilder->getRestrictions()->removeByType(StartTimeRestriction::class);
+        $queryBuilder->getRestrictions()->removeByType(EndTimeRestriction::class);
         return $queryBuilder
             ->select('*')
             ->from(Form::TABLE_NAME)


### PR DESCRIPTION
## Problem

Forms with `starttime` or `endtime` set are invisible in two places in the TYPO3 backend:

1. **Plugin FlexForm selector** — editors cannot select the form when configuring a powermail content element
2. **Powermail backend module overview** — forms do not appear in the module list at all

Additionally, hidden forms do not appear in the backend module, making it impossible to unhide them there.

## Root cause

### FlexForm selector (`FormSelectorUserFunc::getAllForms`)

`DatabaseUtility::getQueryBuilderForTable()` returns a QueryBuilder with TYPO3's `DefaultRestrictionContainer` active. This automatically applies `StartTimeRestriction` and `EndTimeRestriction` based on the form TCA's `enablecolumns`, filtering out any form whose frontend visibility window does not include the current time.

### Backend module (`FormRepository::findAll`, `findAllInPidAndRootline`)

Both methods use Extbase queries without `setIgnoreEnableFields`, so Extbase automatically applies the `disabled`, `starttime`, and `endtime` enable column restrictions.

In both cases `starttime`, `endtime` and `hidden` are **frontend** visibility controls. They should not prevent backend users from accessing or managing form records.

## Fix

**`FormSelectorUserFunc::getAllForms()`**
Remove `StartTimeRestriction` and `EndTimeRestriction` from the QueryBuilder. Hidden forms remain filtered — a hidden form should intentionally not be selectable in the plugin configuration.

**`FormRepository::findAll()` and `findAllInPidAndRootline()`**
Add `setIgnoreEnableFields(true)->setEnableFieldsToBeIgnored(['disabled', 'starttime', 'endtime'])` so all forms appear in the backend module regardless of their current frontend visibility state, allowing editors to manage (hide/unhide/inspect) them freely.

## Affected versions

Tested against TYPO3 13.4 / powermail 13.x.