### PR TITLE
[TASK] Add getters to ReceiverMailSenderPropertiesService

### DIFF
--- a/Classes/Domain/Service/Mail/ReceiverMailSenderPropertiesService.php
+++ b/Classes/Domain/Service/Mail/ReceiverMailSenderPropertiesService.php
@@ -5,6 +5,8 @@ namespace In2code\Powermail\Domain\Service\Mail;
 
 use In2code\Powermail\Domain\Model\Mail;
 use In2code\Powermail\Domain\Repository\MailRepository;
+use In2code\Powermail\Events\ReceiverMailSenderPropertiesGetReplyToEmailEvent;
+use In2code\Powermail\Events\ReceiverMailSenderPropertiesGetReplyToNameEvent;
 use In2code\Powermail\Events\ReceiverMailSenderPropertiesGetSenderEmailEvent;
 use In2code\Powermail\Events\ReceiverMailSenderPropertiesGetSenderNameEvent;
 use In2code\Powermail\Utility\TypoScriptUtility;
@@ -84,5 +86,47 @@ class ReceiverMailSenderPropertiesService
             new ReceiverMailSenderPropertiesGetSenderNameEvent($senderName, $this)
         );
         return $event->getSenderName();
+    }
+
+    /**
+     * Get sender email from configuration in fields and params. If empty, take default from TypoScript
+     *
+     * @throws ExceptionExtbaseObject
+     */
+    public function getReplyToEmail(): string
+    {
+        $defaultSenderEmail = TypoScriptUtility::overwriteValueFromTypoScript(
+            '',
+            $this->configuration['receiver.']['default.'],
+            'senderEmail'
+        );
+        $senderEmail = $this->mailRepository->getSenderMailFromArguments($this->mail, $defaultSenderEmail);
+
+        /** @var ReceiverMailSenderPropertiesGetReplyToEmailEvent $event */
+        $event = $this->eventDispatcher->dispatch(
+            new ReceiverMailSenderPropertiesGetReplyToEmailEvent($senderEmail, $this)
+        );
+        return $event->getReplyToEmail();
+    }
+
+    /**
+     * Get sender name from configuration in fields and params. If empty, take default from TypoScript
+     *
+     * @throws ExceptionExtbaseObject
+     */
+    public function getReplyToName(): string
+    {
+        $defaultSenderName = TypoScriptUtility::overwriteValueFromTypoScript(
+            '',
+            $this->configuration['receiver.']['default.'],
+            'senderName'
+        );
+        $senderName = $this->mailRepository->getSenderNameFromArguments($this->mail, $defaultSenderName);
+
+        /** @var ReceiverMailSenderPropertiesGetReplyToNameEvent $event */
+        $event = $this->eventDispatcher->dispatch(
+            new ReceiverMailSenderPropertiesGetReplyToNameEvent($senderName, $this)
+        );
+        return $event->getReplyToName();
     }
 }

--- a/Classes/Domain/Service/Mail/SendDisclaimedMailPreflight.php
+++ b/Classes/Domain/Service/Mail/SendDisclaimedMailPreflight.php
@@ -52,8 +52,8 @@ class SendDisclaimedMailPreflight
                 'receiverName' => $receiverService->getReceiverName(),
                 'senderEmail' => $senderService->getSenderEmail(),
                 'senderName' => $senderService->getSenderName(),
-                'replyToEmail' => $senderService->getSenderEmail(),
-                'replyToName' => $senderService->getSenderName(),
+                'replyToEmail' => $senderService->getReplyToEmail(),
+                'replyToName' => $senderService->getReplyToName(),
                 'subject' => ObjectUtility::getContentObject()->cObjGetSingle(
                     $this->conf['disclaimer.']['subject'],
                     $this->conf['disclaimer.']['subject.']

--- a/Classes/Events/ReceiverMailSenderPropertiesGetReplyToEmailEvent.php
+++ b/Classes/Events/ReceiverMailSenderPropertiesGetReplyToEmailEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+namespace In2code\Powermail\Events;
+
+use In2code\Powermail\Domain\Service\Mail\ReceiverMailSenderPropertiesService;
+
+final class ReceiverMailSenderPropertiesGetReplyToEmailEvent
+{
+    public function __construct(protected string $senderEmail, protected ReceiverMailSenderPropertiesService $service)
+    {
+    }
+
+    public function getReplyToEmail(): string
+    {
+        return $this->senderEmail;
+    }
+
+    public function setReplyToEmail(string $senderEmail): ReceiverMailSenderPropertiesGetReplyToEmailEvent
+    {
+        $this->senderEmail = $senderEmail;
+        return $this;
+    }
+
+    public function getService(): ReceiverMailSenderPropertiesService
+    {
+        return $this->service;
+    }
+}

--- a/Classes/Events/ReceiverMailSenderPropertiesGetReplyToNameEvent.php
+++ b/Classes/Events/ReceiverMailSenderPropertiesGetReplyToNameEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+namespace In2code\Powermail\Events;
+
+use In2code\Powermail\Domain\Service\Mail\ReceiverMailSenderPropertiesService;
+
+final class ReceiverMailSenderPropertiesGetReplyToNameEvent
+{
+    public function __construct(protected string $senderName, protected ReceiverMailSenderPropertiesService $service)
+    {
+    }
+
+    public function getReplyToName(): string
+    {
+        return $this->senderName;
+    }
+
+    public function setReplyToName(string $senderName): ReceiverMailSenderPropertiesGetReplyToNameEvent
+    {
+        $this->senderName = $senderName;
+        return $this;
+    }
+
+    public function getService(): ReceiverMailSenderPropertiesService
+    {
+        return $this->service;
+    }
+}


### PR DESCRIPTION
- add getReplyToEmail
- add getReplyToName

Both getters have individual events that can be used separate to the sender events.

Both getters provide the same default values as the getSenderEmail / getSenderName unless the events ReceiverMailSenderPropertiesGetReplyToEmailEvent or ReceiverMailSenderPropertiesGetReplyToNameEvent are used to override them

Resolves #1369