### PR TITLE
[BUGFIX] String validation regex not strict enough

### DIFF
--- a/Classes/ViewHelpers/Validation/ValidationDataAttributeViewHelper.php
+++ b/Classes/ViewHelpers/Validation/ValidationDataAttributeViewHelper.php
@@ -218,10 +218,11 @@ class ValidationDataAttributeViewHelper extends AbstractValidationViewHelper
                  * javascript example: <input type="text" data-powermail-pattern="[a-zA-Z]." />
                  */
             case 5:
+                $pattern = $this->settings['validation']['lettersOnlyPattern'] ?? '^[A-Za-z]+$';
                 if ($this->isNativeValidationEnabled()) {
-                    $additionalAttributes['pattern'] = '^[A-Za-z]+$';
+                    $additionalAttributes['pattern'] = $pattern;
                 } elseif ($this->isClientValidationEnabled()) {
-                    $additionalAttributes['data-powermail-pattern'] = '^[a-zA-Z]+$';
+                    $additionalAttributes['data-powermail-pattern'] = $pattern;
                 }
 
                 break;

--- a/Classes/ViewHelpers/Validation/ValidationDataAttributeViewHelper.php
+++ b/Classes/ViewHelpers/Validation/ValidationDataAttributeViewHelper.php
@@ -219,9 +219,9 @@ class ValidationDataAttributeViewHelper extends AbstractValidationViewHelper
                  */
             case 5:
                 if ($this->isNativeValidationEnabled()) {
-                    $additionalAttributes['pattern'] = '[A-Za-z]+';
+                    $additionalAttributes['pattern'] = '^[A-Za-z]+$';
                 } elseif ($this->isClientValidationEnabled()) {
-                    $additionalAttributes['data-powermail-pattern'] = '[a-zA-Z]+';
+                    $additionalAttributes['data-powermail-pattern'] = '^[a-zA-Z]+$';
                 }
 
                 break;

--- a/Configuration/TypoScript/Main/Configuration/10_Validation.typoscript
+++ b/Configuration/TypoScript/Main/Configuration/10_Validation.typoscript
@@ -14,6 +14,8 @@ plugin.tx_powermail.settings.setup {
       fieldset = {$plugin.tx_powermail.settings.validation.morestep.fieldset}
     }
 
+    lettersOnlyPattern = {$plugin.tx_powermail.settings.validation.lettersOnlyPattern}
+
     unique {
       # EXAMPLE: Enable unique check for {email}
       #email = 1

--- a/Configuration/TypoScript/Main/constants.typoscript
+++ b/Configuration/TypoScript/Main/constants.typoscript
@@ -43,6 +43,9 @@ plugin.tx_powermail {
         # cat=powermail_additional//0130; type=boolean; label= Validate User Fieldset Input on Multistep Forms with JavaScript on step change
         fieldset = 0
       }
+
+      # cat=powermail_additional//0140; type=string; label= Pattern for letter-only validation
+      lettersOnlyPattern = ^[A-Za-z]+$
     }
 
     receiver {


### PR DESCRIPTION
* FIX: pattern to validate letter-only
* Make pattern configurable (e.g. for german letters: `^[A-Za-zäüöÄÜÖß]+$`, for french: `^[a-záàéè...]+$`)

Resolves: #1383