### PR TITLE
[TASK] Drop getIdentifier() function from Upgrade Wizards

### DIFF
--- a/Classes/Update/PowermailLanguageUpdateWizard.php
+++ b/Classes/Update/PowermailLanguageUpdateWizard.php
@@ -23,14 +23,6 @@ class PowermailLanguageUpdateWizard implements UpgradeWizardInterface
     /**
      * @return string
      */
-    public function getIdentifier(): string
-    {
-        return 'powermailLanguageUpdateWizard';
-    }
-
-    /**
-     * @return string
-     */
     public function getTitle(): string
     {
         return 'Powermail: Update language settings in mails and answers (relevant for entries from < 8.0.0)';

--- a/Classes/Update/PowermailPermissionSubmoduleUpdater.php
+++ b/Classes/Update/PowermailPermissionSubmoduleUpdater.php
@@ -20,11 +20,6 @@ use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 
 class PowermailPermissionSubmoduleUpdater implements UpgradeWizardInterface
 {
-    public function getIdentifier(): string
-    {
-        return 'powermailPermissionSubmodulesUpdater';
-    }
-
     public function getTitle(): string
     {
         return 'EXT:powermail: Grant permissions for submodules to editors';

--- a/Classes/Update/PowermailPermissionUpdater.php
+++ b/Classes/Update/PowermailPermissionUpdater.php
@@ -20,11 +20,6 @@ use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 
 class PowermailPermissionUpdater implements UpgradeWizardInterface
 {
-    public function getIdentifier(): string
-    {
-        return 'powermailPermissionUpdater';
-    }
-
     public function getTitle(): string
     {
         return 'EXT:powermail: Migrate plugin permissions';

--- a/Classes/Update/PowermailPluginUpdater.php
+++ b/Classes/Update/PowermailPluginUpdater.php
@@ -45,14 +45,6 @@ class PowermailPluginUpdater implements UpgradeWizardInterface
     /**
      * @return string
      */
-    public function getIdentifier(): string
-    {
-        return 'powermailPluginUpdater';
-    }
-
-    /**
-     * @return string
-     */
     public function getTitle(): string
     {
         return 'Powermail: Migrate list types and switchable controller actions to CTypes';

--- a/Classes/Update/PowermailRelationUpdateWizard.php
+++ b/Classes/Update/PowermailRelationUpdateWizard.php
@@ -23,14 +23,6 @@ class PowermailRelationUpdateWizard implements UpgradeWizardInterface
     /**
      * @return string
      */
-    public function getIdentifier(): string
-    {
-        return 'powermailRelationUpdateWizard';
-    }
-
-    /**
-     * @return string
-     */
     public function getTitle(): string
     {
         return 'Powermail: Update relations in database (relevant for entries from < 8.0.0)';


### PR DESCRIPTION
[Deprecation: #99586](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.2/Deprecation-99586-RegistrationOfUpgradeWizardsViaGLOBALS.html)

The definition of the getIdentifier() method has no effect anymore and should be dropped