### PR TITLE
[BUGFIX] Avoid exceptions on NULL pi_flexform

### DIFF
--- a/Classes/Hook/PluginPreviewRenderer.php
+++ b/Classes/Hook/PluginPreviewRenderer.php
@@ -8,6 +8,7 @@ use In2code\Powermail\Domain\Model\Form;
 use In2code\Powermail\Domain\Repository\MailRepository;
 use In2code\Powermail\Events\BackendPageModulePreviewContentEvent;
 use In2code\Powermail\Utility\ConfigurationUtility;
+use In2code\Powermail\Utility\LocalizationUtility;
 use In2code\Powermail\Utility\TemplateUtility;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Backend\Preview\StandardContentPreviewRenderer;
@@ -40,6 +41,10 @@ class PluginPreviewRenderer extends StandardContentPreviewRenderer
     public function renderPageModulePreviewContent(GridColumnItem $item): string
     {
         $row = $item->getRecord();
+
+        if (is_null($row['pi_flexform'])) {
+            return LocalizationUtility::translate('error_no_form');
+        }
 
         $flexFormService = GeneralUtility::makeInstance(FlexFormService::class);
 

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -6,7 +6,7 @@ $EM_CONF[$_EXTKEY] = [
         and easy to use mailform extension with a lots of features
         (spam prevention, marketing information, optin, ajax submit, diagram analysis, etc...)',
     'category' => 'plugin',
-    'version' => '13.1.0',
+    'version' => '13.2.0',
     'state' => 'stable',
     'author' => 'Powermail Development Team',
     'author_email' => 'service@in2code.de',


### PR DESCRIPTION
# Issue

The default value of the `pi_flexform` column in the database is `NULL`.

It is possible for editors to reach that state e.g. by changing the CType of an existing ContentElement, but `GeneralUtility::xml2array` (used in `convertFlexFormContentToArray`) expects a string, causing PHP exceptions in the backend.

## How to reproduce

1. Create a new ContentElement of type Text or Header
2. Change the `CType` field to Powermail
3. When the `Refresh required` popup appears, select `Save and refresh`
4. Close the editing of the ContentElement

Opening the page view in the backend will return a PHP exception:

```
(1/1) TypeError

TYPO3\CMS\Core\Utility\GeneralUtility::xml2array(): Argument #1 ($string) must be of type string, null given, called in /app/vendor/typo3/cms-core/Classes/Service/FlexFormService.php on line 40
```

# Changes

When `pi_flexform` is null, then the rendering of the preview is skipped. Only an error message will be displayed in the backend:

<img width="545" height="120" alt="image" src="https://github.com/user-attachments/assets/0007a1cc-c807-4565-921f-8d0e3eb80c19" />
