### PR TITLE
[BUGFIX] Ensure safe access to confirmation setting in AbstractValidator

### DIFF
--- a/Classes/Domain/Validator/AbstractValidator.php
+++ b/Classes/Domain/Validator/AbstractValidator.php
@@ -100,6 +100,6 @@ abstract class AbstractValidator extends ExtbaseAbstractValidator implements Val
 
     public function isConfirmationActivated(): bool
     {
-        return $this->flexForm['settings']['flexform']['main']['confirmation'] === '1';
+        return ($this->flexForm['settings']['flexform']['main']['confirmation'] ?? '') === '1';
     }
 }


### PR DESCRIPTION
When backend user has restricted flexform access it happens that for example the confirmation key is not stored with the flexform value and then this access would lead to an exception due to missing array key 'confirmation'